### PR TITLE
Test: Added end to end test for LCOH - c8s65gxjrsjgb3brm8im6h9c74c

### DIFF
--- a/src/tests/e2e_lcoh/lcoh_test.py
+++ b/src/tests/e2e_lcoh/lcoh_test.py
@@ -25,7 +25,7 @@ from pyH2A.run_pyH2A import pyH2A
         },
         {
             "input": {
-                "input_file": "src/tests/end_to_end/Pv_E_Base.md",
+                "input_file": "src/tests/end_to_end/PV_E_Base.md",
                 "output_directory": "src/tests/end_to_end/",
             },
             "expected": {

--- a/src/tests/e2e_lcoh/lcoh_test.py
+++ b/src/tests/e2e_lcoh/lcoh_test.py
@@ -7,8 +7,26 @@ from pyH2A.run_pyH2A import pyH2A
     [
         {
             "input": {
-                "input_file": "data/PV_E/Base/PV_E_Base.md",
-                "output_directory": "data/PV_E/Base",
+                "input_file": "src/tests/end_to_end/PEC_Base.md",
+                "output_directory": "src/tests/end_to_end/",
+            },
+            "expected": {
+                "lcoh": 139.41887561917213
+            },
+        },
+        {
+            "input": {
+                "input_file": "src/tests/end_to_end/Photocatalytic_Base.md",
+                "output_directory": "src/tests/end_to_end/",
+            },
+            "expected": {
+                "lcoh": 185.44329282256822
+            },
+        },
+        {
+            "input": {
+                "input_file": "src/tests/end_to_end/Pv_E_Base.md",
+                "output_directory": "src/tests/end_to_end/",
             },
             "expected": {
                 "lcoh": 4.194302976489675
@@ -16,37 +34,19 @@ from pyH2A.run_pyH2A import pyH2A
         },
         {
             "input": {
-                "input_file": "data/PEC/Limit/PEC_Limit.md",
-                "output_directory": "data/PEC/Limit",
+                "input_file": "src/tests/end_to_end/Thermal_Base.md",
+                "output_directory": "src/tests/end_to_end/",
             },
             "expected": {
-                "lcoh": 1.4242951683758598
-            },
-        },
-        {
-            "input": {
-                "input_file": "data/PEC/No_Conc/PEC_Limit_No_Concentration.md",
-                "output_directory": "data/PEC/No_Conc",
-            },
-            "expected": {
-                "lcoh": 15.826371459378658
-            },
-        },
-        {
-            "input": {
-                "input_file": "data/LCA/PV_E_Base.md",
-                "output_directory": ".",
-            },
-            "expected": {
-                "lcoh": 3.5777931317137512
+                "lcoh": 3.270581409704611
             },
         },
     ],
     ids=[
-        "PV_E/Base/PV_E_Base",
-        "PEC/Limit/PEC_Limit",
-        "No_Conc/PEC_No_Concentration",
-        "LCA/PV_E_Base",
+        "PEC_Base",
+        "Photocatalytic_Base",
+        "Pv_E_Base",
+        "Thermal_Base",
     ]
 )
 def test_e2e_lcoh(case):

--- a/src/tests/e2e_lcoh/lcoh_test.py
+++ b/src/tests/e2e_lcoh/lcoh_test.py
@@ -45,7 +45,7 @@ from pyH2A.run_pyH2A import pyH2A
     ids=[
         "PEC_Base",
         "Photocatalytic_Base",
-        "Pv_E_Base",
+        "PV_E_Base",
         "Thermal_Base",
     ]
 )

--- a/src/tests/e2e_lcoh/lcoh_test.py
+++ b/src/tests/e2e_lcoh/lcoh_test.py
@@ -1,0 +1,79 @@
+import pytest
+from pyH2A.run_pyH2A import pyH2A
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        {
+            "input": {
+                "input_file": "data/PV_E/Base/PV_E_Base.md",
+                "output_directory": "data/PV_E/Base",
+            },
+            "expected": {
+                "lcoh": 4.194302976489675
+            },
+        },
+        {
+            "input": {
+                "input_file": "data/PEC/Limit/PEC_Limit.md",
+                "output_directory": "data/PEC/Limit",
+            },
+            "expected": {
+                "lcoh": 1.4242951683758598
+            },
+        },
+        {
+            "input": {
+                "input_file": "data/PEC/No_Conc/PEC_Limit_No_Concentration.md",
+                "output_directory": "data/PEC/No_Conc",
+            },
+            "expected": {
+                "lcoh": 15.826371459378658
+            },
+        },
+        {
+            "input": {
+                "input_file": "data/LCA/PV_E_Base.md",
+                "output_directory": ".",
+            },
+            "expected": {
+                "lcoh": 3.5777931317137512
+            },
+        },
+    ],
+    ids=[
+        "PV_E/Base/PV_E_Base",
+        "PEC/Limit/PEC_Limit",
+        "No_Conc/PEC_No_Concentration",
+        "LCA/PV_E_Base",
+    ]
+)
+def test_e2e_lcoh(case):
+    """
+    End-to-end regression test for Levelized Cost of Hydrogen (LCOH).
+
+    This test runs the full pyH2A workflow using reference input files
+    and asserts that the computed LCOH matches the master-branch
+    reference value within tight numerical tolerance.
+
+    Purpose:
+    - Detect unintended economic logic changes
+    - Detect numerical drift
+    - Protect financial model stability
+    """
+    
+    input_data = case["input"]
+    
+    result = pyH2A(
+        input_data["input_file"], 
+        input_data["output_directory"]
+    )
+    
+    # Very strict tolerance to detect economic regression
+    tolerance = 1e-12
+    
+    assert result.base_case.h2_cost == pytest.approx(
+        case["expected"]["lcoh"],
+        rel=tolerance
+    )


### PR DESCRIPTION
**Description**

- Added end-to-end (E2E) tests for Levelized Cost of Hydrogen (LCOH).
- Tests use reference input files and validate computed LCOH against master-branch reference values with strict numerical tolerance (`1e-12`).

**Motivation / Background**

- Improves regression safety for the economic model.
- Ensures correctness of Discounted Cash Flow (DCF) calculations.
- Protects LCOH outputs against unintended logic changes.
- Verifies that plugin behavior remains stable when modifications are introduced.
- Increases overall test readability, maintainability, and scalability.

**Type of Change**

- [x] Test addition

**How Has This Been Tested?**

- All tests pass locally using:
`uv run pytest src/tests/e2e_lcoh -v`

- Verified deterministic LCOH outputs across all reference cases.

**Checklist**

- [x] Tests added and passing  
- [x] Strict tolerance applied for regression protection  
- [x] Comments added explaining test intent and tolerance  
- [x] Implemented all requested changes from the previous testing PR

**Screenshot**
<img width="1297" height="352" alt="image" src="https://github.com/user-attachments/assets/c696c482-4e8b-46aa-b540-f8090b2f0054" />



