### PR TITLE
Python code formatter using autopep8 -  cre1838ea7tn47r85dyco11ifbw

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8",
+    "editor.formatOnSave": true
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">= 3.9"
 dependencies = [
     "autodocsumm>=0.2.14",
+    "autopep8>=2.3.2",
     "click>=8.1.8",
     "furo>=2025.9.25",
     "matplotlib>=3.9.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-click>=7.1.2
-numpy
-scipy
-pandas
-matplotlib
-numpydoc
-autodocsumm
-furo
-pytest>=8.4.2

--- a/src/pyH2A.egg-info/PKG-INFO
+++ b/src/pyH2A.egg-info/PKG-INFO
@@ -10,6 +10,7 @@ Description-Content-Type: text/markdown
 License-File: LICENSE
 License-File: LICENSE-CC-BY.txt
 Requires-Dist: autodocsumm>=0.2.14
+Requires-Dist: autopep8>=2.3.2
 Requires-Dist: click>=8.1.8
 Requires-Dist: furo>=2025.9.25
 Requires-Dist: matplotlib>=3.9.4

--- a/src/pyH2A.egg-info/requires.txt
+++ b/src/pyH2A.egg-info/requires.txt
@@ -1,4 +1,5 @@
 autodocsumm>=0.2.14
+autopep8>=2.3.2
 click>=8.1.8
 furo>=2025.9.25
 matplotlib>=3.9.4

--- a/uv.lock
+++ b/uv.lock
@@ -69,6 +69,19 @@ wheels = [
 ]
 
 [[package]]
+name = "autopep8"
+version = "2.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycodestyle" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1942,6 +1955,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1956,6 +1978,7 @@ version = "0.0a8"
 source = { editable = "." }
 dependencies = [
     { name = "autodocsumm" },
+    { name = "autopep8" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "furo" },
@@ -1980,6 +2003,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "autodocsumm", specifier = ">=0.2.14" },
+    { name = "autopep8", specifier = ">=2.3.2" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "furo", specifier = ">=2025.9.25" },
     { name = "matplotlib", specifier = ">=3.9.4" },


### PR DESCRIPTION
# Motivation / Background
- There are unnecessary code diffs because of using different formatters and IDEs by developers. To maintain a single format, this unified formatter has been implemented. But everyone needs to use VS Code, as we all use VS Code as standard practice.

# Related Issue(s)

# Type of Change
Please check all that apply:
- [x] Bug fix (non-breaking change)
- [x] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change

# How Has This Been Tested?
- [] Manual tests / example model runs

## Test Details:
Visually verified the corrected template renders correctly in `.github/pull_request_template.md`.

# Checklist
- [x] Code follows pyH2A style guidelines
- [x] Self-review of code completed
- [ ] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, ReadTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [x] No new warnings generated
- [ ] Tests added / updated and passing
- [ ] Dependent changes merged and published