### PR TITLE
Refactor: Fix typo in power_management_plugin (vale → value) - c3qmqymptxjgtbc3ppousxgnsth

### DIFF
--- a/src/pyH2A/Plugins/Power_Management_Plugin.py
+++ b/src/pyH2A/Plugins/Power_Management_Plugin.py
@@ -58,7 +58,7 @@ class Power_Management_Plugin:
         insert(dcf, 'Power Generation', 'Stored Power (daily, kWh)', 'Value',
                 0, __name__, print_info = print_info)
         
-        insert(dcf, 'Grid Electricity', 'Used grid electricity (yearly, kWh)', 'Vale',
+        insert(dcf, 'Grid Electricity', 'Used grid electricity (yearly, kWh)', 'Value',
                 self.total_unfulfilled, __name__, print_info = print_info)
         
         insert(dcf, 'Other Variable Operating Cost - Grid Electricity', 'Cost of grid electricity (yearly, $)', 'Value',


### PR DESCRIPTION
**Description**  

This PR fixes a typo in the `power_management_plugin` where the variable name `vale` was incorrectly used instead of `value`.

- Corrected `vale` → `value`  
- Ensures consistent variable naming and prevents potential runtime errors or misinterpretation  

This change is minimal and does not alter intended functionality beyond correcting the bug.

**Motivation / Background**  

A typo in variable naming (`vale`) could lead to:
- Runtime errors (e.g., undefined variable usage)
- Incorrect data handling depending on context
- Reduced code readability and maintainability  

Fixing this improves reliability and aligns with expected naming conventions across pyH2A.

**Type of Change**  

Please check all that apply:  
- [x] Bug fix (non-breaking change)  

**How Has This Been Tested?**  

The fix was verified through basic execution and validation of the affected module.

- [x] Unit tests  