### PR TITLE
Feat: create output resolver test data - chbwm8q3sptrhmjuiosehxsqcta

### DIFF
--- a/src/tests/Utilities/output_resolver/output_resolver_test_data.py
+++ b/src/tests/Utilities/output_resolver/output_resolver_test_data.py
@@ -1,0 +1,312 @@
+import numpy as np
+from pint import UnitRegistry
+
+ureg = UnitRegistry()
+ureg.define('USD = [currency]')
+
+
+class DummyDCF:
+    def __init__(self):
+        # Initial state of the dict, before any insert or update: some keys of various levels already exist, we want to check if the output resolver updates / adds values correctly  
+        self.inp = {
+            'Utilities': {
+                'Natural gas': {
+                    'Usage_Value': 1500,
+                    'Usage_Unit': 'kWh/kg',
+                    'Cost_Value': 200,
+                    'Cost_Unit': 'USD/kWh',
+                    'Type': 'natural_gas'
+                }
+            },                       
+            'Power Generation': {
+                'Available Energy (daily)': {
+                    'Value': {
+                        '2025':np.array([400., 250., 350.]), 
+                        '2024':np.array([500., 350., 450.])
+                    }, 
+                    'Unit': 'kWh'
+                },
+            }, 
+            'Dummy left Direct Capital Cost dummy right': {
+                'First cost': {
+                    'Value': 750.0,
+                    'Unit': 'USD'
+                },
+                'Second cost': {
+                    'Value': 250.0,
+                    'Unit': 'USD'
+                },                
+            }, 
+
+        }
+
+# quantities to insert : these would be the quantities calculated by the plugin
+# that is: the self.XXX variables (that would now be pint quantities)
+# written here under the form of a dict for convenience
+# i.e. we write here directly the dict location where the value would go to ease testing, but in the plugin these would be self.XXX quantities, not dict items
+values_to_insert = {
+    'Power Generation':{
+        'Stored Energy (daily)':{ # new middle key to insert
+            'Value': {
+                np.int64(0): ureg.Quantity(np.array([0, 0, 938736, 0, 1008000]), 'J'),
+                np.int64(1): ureg.Quantity(np.array([0, 0, 933840, 0, 1005480]), 'J'), 
+            }
+        }, 
+        'Available Energy (daily)':{ # overwrite existing value
+            'Value': {
+                '2025':ureg.Quantity(np.array([5.4e8, 3.6e8, 7.2e8]), 'J'), 
+                '2024':ureg.Quantity(np.array([1.26e9, 7.2e8, 1.08e9]), 'J') 
+            }
+        },         
+    },
+
+
+    'Dummy left Direct Capital Cost dummy right':{
+        'Summed Total':{
+            'Value': ureg.Quantity(1000.0, 'USD')
+        }, 
+    }, 
+
+    'Direct Capital Costs':{
+        'Inflated':{
+            'Value': ureg.Quantity(2000.0, 'USD')
+        }, 
+    }, 
+
+    'Technical Operating Parameters and Specifications':{
+        'Plant daily design flowrate':{
+            'Value': ureg.Quantity(np.array([0., 955.95413492, 952.47095234, 948.98391499]), 'kg/day')
+        }, 
+        'Scaling Ratio':{
+            'Value': ureg.Quantity(1.0, 'dimensionless')
+        },         
+    }, 
+
+    'Power Consumption':{
+        'Reverse Osmosis Consumption (yearly)':{
+            'Value': ureg.Quantity(np.array([1.3e9, 1.e9]), 'J'), 
+            'Type': 'flexible'
+        }, 
+    }, 
+
+    'Reactor Baggies':{
+        'Number':{
+            'Value': ureg.Quantity(5, 'dimensionless'), 
+        }, 
+    },    
+
+    'Planned Replacement':{
+        'Planned Replacement Baggie':{
+            'Cost': ureg.Quantity(1000, 'USD'), 
+            'Frequency': ureg.Quantity(2, 'year'), 
+        }, 
+    },   
+
+}
+
+# Output schema (output equivalent to input_dict)
+output_dict = {
+    'Power Generation': {
+        'Stored Energy (daily)': {
+            'Value': {
+                'type': {dict},
+            },
+            'Unit': 'J', # I didn't keep a 'dimension' subkey here, I think there's no need to validate the dimension on the output side. 
+                         # Actually I'm not even sure we need to keep the unit here, since it is included in the calculated pint quantity already
+            'optional': False,
+            'description': 'Electricity stored in battery daily (dictionary of years)'
+        }, 
+        'Available Energy (daily)': {
+            'Value': {
+                'type': {dict},
+            },
+            'Unit': 'J', 
+            'optional': False,
+            'description': 'Available Electricity, daily basis, dictionary of years - energy which has not been stored in battery'
+        }        
+    }, 
+  
+    '<...> Direct Capital Cost <...>': {
+        'Summed Total': {
+            'Value': {
+                'type': {float},
+            },
+            'Unit': 'USD', 
+            'optional': False,
+            'description': 'Summed total for each individual table in "Direct Capital Cost" group.'
+        }
+    }, 
+
+    'Direct Capital Costs': {
+        'Inflated': {
+            'Value': {
+                'type': {float},
+            },
+            'Unit': 'USD', 
+            'optional': False,
+            'description': 'Total direct capital costs multiplied by combined inflator.'
+        }
+    },    
+
+    'Technical Operating Parameters and Specifications': { 
+        'Plant Design Capacity (Daily)': {# I renamed the existing Plant Design Capacity (kg of H2/day)
+            'Value': {
+                'type': {float, np.ndarray},
+            },
+            'Unit': 'kg', 
+            'optional': False,
+            'description': 'Plant design capacity expressed as a daily flowrate, calculated from installed electrolysis power capacity and hourly power generation data.'
+        },
+        'Scaling Ratio': {
+            'Value': {
+                'type': {float},
+            },
+            'Unit': 'dimensionless', 
+            'optional': True,
+            'description': 'Returned if New Plant Design Capacity was specified.'
+        }        
+    },  
+
+    'Scaling': { # this one is optional, and we actually don't insert any value (check the ability of the output resolver to handle an optional value that is absent)
+        'Capital Scaling Factor': {
+            'Value': {
+                'type': {float},
+            },
+            'Unit': 'dimensionless', 
+            'optional': True,
+            'description': 'Returned if scaling is active (`Scaling Ratio` or `New Plant Design Capacity (kg of H2/day)` specified).'
+        }
+    },
+
+    'Power Consumption': {
+        'Reverse Osmosis Consumption (yearly)': {
+            'Value': {
+                'type': {np.ndarray},
+            },
+            'Unit': 'J', 
+            'Type': {
+                'type': str,
+                'options': {'flexible', 'on demand'} 
+            },
+            'optional': False,
+            'description': ' Electricity demand of reverse osmosis plant per year.'
+        }
+    },
+
+    'Reactor Baggies': {
+        'Number': {
+            'Value': {
+                'type': {int},
+            },
+            'Unit': 'dimensionless', 
+            'optional': False,
+            'description': ' Number of ports per baggie.'
+        }
+    },    
+
+    'Planned Replacement': {
+        'Planned Replacement Baggie': {
+            'Cost_Value': {
+                'type': {float},
+            },
+            'Cost_Unit': 'USD',
+            'Frequency_Value': {
+                'type': {float},
+            },
+            'Frequency_Unit': 'year', # keeping years here, it seems more coherent              
+            'optional': False,
+            'description': ' Replacement frequency and cost of baggies'
+        }
+    },       
+}
+
+
+# Expected final state, that is: what dcf.inp would look like after insertions
+resolved_dict_expected = {
+    # Values that were initially present, and have not been modified : they must still be there at the end
+    'Utilities': {
+        'Natural gas': {
+            'Usage_Value': 1500,
+            'Usage_Unit': 'kWh/kg',
+            'Cost_Value': 200,
+            'Cost_Unit': 'USD/kWh',
+            'Type': 'natural_gas'
+        }
+    },        
+    'Dummy left Direct Capital Cost dummy right': {
+        'First cost': {
+            'Value': 750.0,
+            'Unit': 'USD'
+        },
+        'Second cost': {
+            'Value': 250.0,
+            'Unit': 'USD'
+        },                
+        'Summed Total': { # new mid key
+            'Value': 1000.0, 
+            'Unit': 'USD'            
+        }        
+    }, 
+    
+    'Power Generation': { # upper key existed already
+        'Available Energy (daily)': { # Value that was initially present, and has been modified
+            'Value': {
+                '2025':np.array([5.4e8, 3.6e8, 7.2e8]), 
+                '2024':np.array([1.26e9, 7.2e8, 1.08e9]) 
+            }, 
+            'Unit': 'J'            
+        }, 
+        'Stored Energy (daily)': { # Value that has been inserted
+            'Value': {
+                np.int64(0): np.array([0, 0, 938736, 0, 1008000]), 
+                np.int64(1): np.array([0, 0, 933840, 0, 1005480]), 
+            }, 
+            'Unit': 'J'            
+        }        
+    }, 
+
+    'Direct Capital Costs': { # upper key didn't exist in the initial dictionary
+        'Inflated': {
+            'Value': 2000.0, 
+            'Unit': 'USD'            
+        }
+    }, 
+
+    'Technical Operating Parameters and Specifications': { 
+        'Plant Design Capacity (Daily)': {
+            'Value': np.array([0., 955.95413492, 952.47095234, 948.98391499]), 
+            'Unit': 'kg'            
+        },
+        'Scaling Ratio': { # inserted optional value
+            'Value': 1.0, 
+            'Unit': 'dimensionless'            
+        }        
+    }, 
+
+    'Power Consumption': {
+        'Reverse Osmosis Consumption (yearly)': {
+            'Value': np.array([1.3e9, 1.e9]),
+            'Unit': 'J',
+            'Type': 'flexible'
+        }
+    },       
+
+    'Reactor Baggies': {
+        'Number': {
+            'Value': 5,
+            'Unit': 'dimensionless',
+        }
+    },   
+
+    'Planned Replacement': {
+        'Planned Replacement Baggie': {
+            'Cost_Value': 1000,
+            'Cost_Unit': 'USD',
+            'Frequency_Value': 2,
+            'Frequency_Unit': 'year',
+        }
+    },   
+
+}
+
+

--- a/src/tests/Utilities/output_resolver/output_resolver_test_data.py
+++ b/src/tests/Utilities/output_resolver/output_resolver_test_data.py
@@ -16,7 +16,8 @@ class DummyDCF:
                     'Usage_Unit': 'kWh/kg',
                     'Cost_Value': 200,
                     'Cost_Unit': 'USD/kWh',
-                    'Type': 'natural_gas'
+                    'Type': 'natural_gas', 
+                    'Processed': 'Yes'
                 }
             },                       
             'Power Generation': {
@@ -25,20 +26,30 @@ class DummyDCF:
                         '2025':np.array([400., 250., 350.]), 
                         '2024':np.array([500., 350., 450.])
                     }, 
-                    'Unit': 'kWh'
+                    'Unit': 'kWh', 
+                    'Processed': 'Yes'
                 },
             }, 
             'Dummy left Direct Capital Cost dummy right': {
                 'First cost': {
                     'Value': 750.0,
-                    'Unit': 'USD'
+                    'Unit': 'USD', 
+                    'Processed': 'Yes'
                 },
                 'Second cost': {
                     'Value': 250.0,
-                    'Unit': 'USD'
+                    'Unit': 'USD', 
+                    'Processed': 'Yes'
                 },                
             }, 
-
+            'Planned Replacement': {
+                'Electrolyzer Stack Replacement': {
+                    'Cost_Value': 0.4,
+                    'Cost_Unit': 'USD',                     
+                    'Path': 'Direct Capital Costs - Electrolyzer > Electrolyzer CAPEX ($/kW) > Value', 
+                    'Comment': 'Based on Chang 2020'
+                },               
+            }, 
         }
 
 # quantities to insert : these would be the quantities calculated by the plugin
@@ -60,7 +71,6 @@ values_to_insert = {
             }
         },         
     },
-
 
     'Dummy left Direct Capital Cost dummy right':{
         'Summed Total':{
@@ -101,6 +111,9 @@ values_to_insert = {
             'Cost': ureg.Quantity(1000, 'USD'), 
             'Frequency': ureg.Quantity(2, 'year'), 
         }, 
+        'Electrolyzer Stack Replacement':{
+            'Frequency': ureg.Quantity(10, 'year'), 
+        },         
     },   
 
 }
@@ -216,8 +229,18 @@ output_dict = {
             },
             'Frequency_Unit': 'year', # keeping years here, it seems more coherent              
             'optional': False,
-            'description': ' Replacement frequency and cost of baggies'
-        }
+            'description': ' Replacement frequency and cost of baggies', 
+        }, 
+        'Electrolyzer Stack Replacement': {
+            'Frequency_Value': {
+                'type': {float},
+            },
+            'Frequency_Unit': 'year', # keeping years here, it seems more coherent              
+            'optional': False, 
+            'description': 'Frequency of electrolyzer stack replacements, calculated from replacement time and hourly irradiation data', 
+            'add_processed' = False,  # when add_processed and insert_path are different from the default value, the output resolver must read it from output_dict to inform the 'insert' method accordingly
+            'insert_path' = False
+        },            
     },       
 }
 
@@ -231,21 +254,25 @@ resolved_dict_expected = {
             'Usage_Unit': 'kWh/kg',
             'Cost_Value': 200,
             'Cost_Unit': 'USD/kWh',
-            'Type': 'natural_gas'
+            'Type': 'natural_gas', 
+            'Processed': 'Yes'
         }
     },        
     'Dummy left Direct Capital Cost dummy right': {
         'First cost': {
             'Value': 750.0,
-            'Unit': 'USD'
+            'Unit': 'USD', 
+            'Processed': 'Yes'
         },
         'Second cost': {
             'Value': 250.0,
-            'Unit': 'USD'
+            'Unit': 'USD', 
+            'Processed': 'Yes'
         },                
         'Summed Total': { # new mid key
             'Value': 1000.0, 
-            'Unit': 'USD'            
+            'Unit': 'USD', 
+            'Processed': 'Yes'            
         }        
     }, 
     
@@ -255,32 +282,37 @@ resolved_dict_expected = {
                 '2025':np.array([5.4e8, 3.6e8, 7.2e8]), 
                 '2024':np.array([1.26e9, 7.2e8, 1.08e9]) 
             }, 
-            'Unit': 'J'            
+            'Unit': 'J', 
+            'Processed': 'Yes'            
         }, 
         'Stored Energy (daily)': { # Value that has been inserted
             'Value': {
                 np.int64(0): np.array([0, 0, 938736, 0, 1008000]), 
                 np.int64(1): np.array([0, 0, 933840, 0, 1005480]), 
             }, 
-            'Unit': 'J'            
+            'Unit': 'J', 
+            'Processed': 'Yes'            
         }        
     }, 
 
     'Direct Capital Costs': { # upper key didn't exist in the initial dictionary
         'Inflated': {
             'Value': 2000.0, 
-            'Unit': 'USD'            
+            'Unit': 'USD', 
+            'Processed': 'Yes'            
         }
     }, 
 
     'Technical Operating Parameters and Specifications': { 
         'Plant Design Capacity (Daily)': {
             'Value': np.array([0., 955.95413492, 952.47095234, 948.98391499]), 
-            'Unit': 'kg'            
+            'Unit': 'kg', 
+            'Processed': 'Yes'            
         },
         'Scaling Ratio': { # inserted optional value
             'Value': 1.0, 
-            'Unit': 'dimensionless'            
+            'Unit': 'dimensionless',  
+            'Processed': 'Yes'
         }        
     }, 
 
@@ -288,7 +320,8 @@ resolved_dict_expected = {
         'Reverse Osmosis Consumption (yearly)': {
             'Value': np.array([1.3e9, 1.e9]),
             'Unit': 'J',
-            'Type': 'flexible'
+            'Type': 'flexible', 
+            'Processed': 'Yes'
         }
     },       
 
@@ -296,6 +329,7 @@ resolved_dict_expected = {
         'Number': {
             'Value': 5,
             'Unit': 'dimensionless',
+            'Processed': 'Yes'
         }
     },   
 
@@ -305,7 +339,16 @@ resolved_dict_expected = {
             'Cost_Unit': 'USD',
             'Frequency_Value': 2,
             'Frequency_Unit': 'year',
-        }
+            'Processed': 'Yes'
+        }, 
+        'Electrolyzer Stack Replacement': {
+            'Cost_Value': 0.4,
+            'Cost_Unit': 'USD',             
+            'Path': 'Direct Capital Costs - Electrolyzer > Electrolyzer CAPEX ($/kW) > Value', 
+            'Comment': 'Based on Chang 2020',
+            'Frequency_Value': np.float64(10.0),
+            'Frequency_Unit': 'year'
+        },          
     },   
 
 }
@@ -342,16 +385,16 @@ class TestOutputResolver:
             return
 
     def _apply_values(self, dcf):
-        """Simulate plugin behavior: we would manually in which dict location to insert a self.XXX value"""
+        """Simulate plugin behavior: we would manually specify, in the output_resolver call, in which dict location (keys) to insert a self.XXX value"""
         for top_key, mid_dict in values_to_insert.items():
             for mid_key, leaf_dict in mid_dict.items():
-                for leaf_key, value in leaf_dict.items():
+                for leaf_key, value_to_insert in leaf_dict.items():
                     output_resolver(
                         dcf,
                         top_key,
                         mid_key,
                         leaf_key,
-                        value,
+                        value_to_insert,
                         output_dict
                     )
 

--- a/src/tests/Utilities/output_resolver/output_resolver_test_data.py
+++ b/src/tests/Utilities/output_resolver/output_resolver_test_data.py
@@ -1,6 +1,8 @@
 import numpy as np
 from pint import UnitRegistry, Quantity
 import pytest
+import unittest
+from pyH2A.Utilities.input_modification output_resolver
 
 ureg = UnitRegistry()
 ureg.define('USD = [currency]')
@@ -50,199 +52,163 @@ class DummyDCF:
                     'Comment': 'Based on Chang 2020'
                 },               
             }, 
+            'Catalyst': {
+                'Lifetime': {
+                    'Value': 0.5,
+                    'Unit': 'year', 
+                },
+            }
         }
 
-# quantities to insert : these would be the quantities calculated by the plugin
-# that is: the self.XXX variables (that would now be pint quantities)
-# written here under the form of a dict for convenience
-# i.e. we write here directly the dict location where the value would go to ease testing, but in the plugin these would be self.XXX quantities, not dict items
-values_to_insert = {
-    'Power Generation':{
-        'Stored Energy (daily)':{ # new middle key to insert
-            'Value': {
-                np.int64(0): ureg.Quantity(np.array([0, 0, 938736, 0, 1008000]), 'J'),
-                np.int64(1): ureg.Quantity(np.array([0, 0, 933840, 0, 1005480]), 'J'), 
+
+# we need a dummy plugin to contain the variables to insert
+class DummyPlugin:
+    # Output schema (output equivalent to input_dict)
+    output_dict = { 
+        'Power Generation': {
+            'Stored Energy (daily)': { # new middle key to insert
+                'Value': 'self.yearly_recovered_power',
+                'add_processed' : True,  # This is the default so shouldn't be needed anyway, but it doesn't harm to test the explicit specification of it
+                'insert_path' : True,            
+                'description': 'Electricity stored in battery daily (dictionary of years)',
+                'optional': False,            
+            }, 
+            'Available Energy (daily)': { # overwrite existing value
+                # From now on, I don't add 'add_processed' and 'insert_path' when they are true, it's the default so normally it'S unnecessary
+                'Value': 'self.yearly_unstored_power', 
+                'description': 'Available Electricity, daily basis, dictionary of years - energy which has not been stored in battery',
+                'optional': False,            
+            }        
+        }, 
+    
+        '<...> Direct Capital Cost <...>': { # actually I'm confused about this one, the docstring says we insert [...] Direct Capital Cost [...] > Summed Total > Value, but I don't find such an insert. So I use it here for the test as an example anyway but in the capital cost plugin we might need to clarify it
+            'Summed Total': {
+                'Value': 'self.total',
+                'description': 'Summed total for each individual table in "Direct Capital Cost" group.', 
+                'optional': False,
             }
         }, 
-        'Available Energy (daily)':{ # overwrite existing value
-            'Value': {
-                '2025':ureg.Quantity(np.array([5.4e8, 3.6e8, 7.2e8]), 'J'), 
-                '2024':ureg.Quantity(np.array([1.26e9, 7.2e8, 1.08e9]), 'J') 
+
+        'Direct Capital Costs': {
+            'Inflated': {
+                'Value': 'self.direct_inflated', # this one is not normally a self.XXX, but if we don't turn it into a self.XXX I suspect it won't work
+                'description': 'Total direct capital costs multiplied by combined inflator.', 
+                'optional': False,            
             }
-        },         
-    },
+        },    
 
-    'Dummy left Direct Capital Cost dummy right':{
-        'Summed Total':{
-            'Value': ureg.Quantity(1000.0, 'USD')
-        }, 
-    }, 
-
-    'Direct Capital Costs':{
-        'Inflated':{
-            'Value': ureg.Quantity(2000.0, 'USD')
-        }, 
-    }, 
-
-    'Technical Operating Parameters and Specifications':{
-        'Plant daily design flowrate':{
-            'Value': ureg.Quantity(np.array([0., 955.95413492, 952.47095234, 948.98391499]), 'kg/day')
-        }, 
-        'Scaling Ratio':{
-            'Value': ureg.Quantity(1.0, 'dimensionless')
-        },         
-    }, 
-
-    'Power Consumption':{
-        'Reverse Osmosis Consumption (yearly)':{
-            'Value': ureg.Quantity(np.array([1.3e9, 1.e9]), 'J'), 
-            'Type': 'flexible'
-        }, 
-    }, 
-
-    'Reactor Baggies':{
-        'Number':{
-            'Value': ureg.Quantity(5, 'dimensionless'), 
-        }, 
-    },    
-
-    'Planned Replacement':{
-        'Planned Replacement Baggie':{
-            'Cost': ureg.Quantity(1000, 'USD'), 
-            'Frequency': ureg.Quantity(2, 'year'), 
-        }, 
-        'Electrolyzer Stack Replacement':{
-            'Frequency': ureg.Quantity(10, 'year'), 
-        },         
-    },   
-
-}
-
-# Output schema (output equivalent to input_dict)
-output_dict = {
-    'Power Generation': {
-        'Stored Energy (daily)': {
-            'Value': {
-                'type': {dict},
+        'Technical Operating Parameters and Specifications': { 
+            'Plant design flowrate': {# I renamed the existing Plant Design Capacity (kg of H2/day)
+                'Value': 'self.h2_production', #originally there's a division by 365 that iswill require update in the plugin
+                'description': 'Plant design capacity expressed as a daily flowrate, calculated from installed electrolysis power capacity and hourly power generation data.', 
+                'optional': False,
             },
-            'Unit': 'J', # I didn't keep a 'dimension' subkey here, I think there's no need to validate the dimension on the output side. 
-                         # Actually I'm not even sure we need to keep the unit here, since it is included in the calculated pint quantity already
-            'optional': False,
-            'description': 'Electricity stored in battery daily (dictionary of years)'
-        }, 
-        'Available Energy (daily)': {
-            'Value': {
-                'type': {dict},
-            },
-            'Unit': 'J', 
-            'optional': False,
-            'description': 'Available Electricity, daily basis, dictionary of years - energy which has not been stored in battery'
-        }        
-    }, 
-  
-    '<...> Direct Capital Cost <...>': {
-        'Summed Total': {
-            'Value': {
-                'type': {float},
-            },
-            'Unit': 'USD', 
-            'optional': False,
-            'description': 'Summed total for each individual table in "Direct Capital Cost" group.'
-        }
-    }, 
+            'Scaling Ratio': { # optional
+                'Value': 'self.scaling_ratio', # isn't normally a "self"
+                'description': 'Returned if New Plant Design Capacity was specified.', 
+                'optional': True,            
+            }        
+        },  
 
-    'Direct Capital Costs': {
-        'Inflated': {
-            'Value': {
-                'type': {float},
-            },
-            'Unit': 'USD', 
-            'optional': False,
-            'description': 'Total direct capital costs multiplied by combined inflator.'
-        }
-    },    
-
-    'Technical Operating Parameters and Specifications': { 
-        'Plant Design Capacity (Daily)': {# I renamed the existing Plant Design Capacity (kg of H2/day)
-            'Value': {
-                'type': {float, np.ndarray},
-            },
-            'Unit': 'kg', 
-            'optional': False,
-            'description': 'Plant design capacity expressed as a daily flowrate, calculated from installed electrolysis power capacity and hourly power generation data.'
+        'Scaling': { # this one is optional, and we actually don't insert any value (to check the ability of the output resolver to handle an optional value that is absent)
+            'Capital Scaling Factor': {
+                'Value': 'self.capital_scaling_factor',
+                'description': 'Returned if scaling is active (`Scaling Ratio` or `New Plant Design Capacity (kg of H2/day)` specified).', 
+                'optional': True,            
+            }
         },
-        'Scaling Ratio': {
-            'Value': {
-                'type': {float},
-            },
-            'Unit': 'dimensionless', 
-            'optional': True,
-            'description': 'Returned if New Plant Design Capacity was specified.'
+
+        'Power Consumption': {
+            'Reverse Osmosis Consumption (yearly)': {
+                'Value': 'self.electricity_demand',
+                'Type': 'flexible', # no need to have the intermediate "options" key anymore: in the same way as we define here the inserted variables, we define directly the Type
+                'description': ' Electricity demand of reverse osmosis plant per year.',      
+                'optional': False,                   
+            }
+        },
+
+        'Reactor Baggies': {
+            'Number': {
+                'Value': 'self.baggie_number',
+                'description': 'Number of individual baggies required for design H2 production capacity', 
+                'optional': False,            
+            }
+        },    
+
+        'Planned Replacement': {
+            'Planned Replacement Baggie': {
+                'Cost_Value': 'self.baggies_cost',
+                'Frequency_Value': 'self.baggie_frequency',
+                'description': ' Replacement frequency and cost of baggies',             
+                'optional': False,                
+            }, 
+            'Planned Replacement Catalyst': {
+                'Frequency_Value': 'self.input_dict_resolved["Catalyst"]["Lifetime"]["Value"]', # interesting because in the existing version we insert something that should already be in the dictionary ('dcf.inp['Catalyst']['Lifetime']['Value']'), not a variable that results from a calculation
+                                                                                    # rather than picking up the value from dcf.inp (as we currently do), it's better to now pick it up from the resolved dict so we know already it's "clean"        
+                'description': 'Replacement frequency of catalyst in years, identical to catalyst lifetime.', 
+                'optional': False,             
+            },           
+            'Electrolyzer Stack Replacement': {
+                'Frequency_Value': 'self.replacement_frequency',
+                'description': 'Frequency of electrolyzer stack replacements, calculated from replacement time and hourly irradiation data', 
+                'optional': False,             
+                'add_processed' : False,  # when add_processed and insert_path are different from the default value, the output resolver must read it from output_dict to inform the 'insert' method accordingly
+                'insert_path' : False
+            },            
+        },       
+    }
+
+    def __init__(self, dcf, print_info):
+        self.input_dict_resolved = { # sometimes we need to pick up some values from the resolved dict that exists in the plugin, that is created after the input_resolver calls
+            'Catalyst': {
+                'Lifetime': {
+                    'Value': ureg.Quantity(1.57788E8, 's')
+                }
+            }
         }        
-    },  
-
-    'Scaling': { # this one is optional, and we actually don't insert any value (check the ability of the output resolver to handle an optional value that is absent)
-        'Capital Scaling Factor': {
-            'Value': {
-                'type': {float},
-            },
-            'Unit': 'dimensionless', 
-            'optional': True,
-            'description': 'Returned if scaling is active (`Scaling Ratio` or `New Plant Design Capacity (kg of H2/day)` specified).'
+        self.yearly_recovered_power = {
+            np.int64(0): ureg.Quantity(np.array([0, 0, 938736, 0, 1008000]), 'J'),
+            np.int64(1): ureg.Quantity(np.array([0, 0, 933840, 0, 1005480]), 'J'),
         }
-    },
 
-    'Power Consumption': {
-        'Reverse Osmosis Consumption (yearly)': {
-            'Value': {
-                'type': {np.ndarray},
-            },
-            'Unit': 'J', 
-            'Type': {
-                'type': str,
-                'options': {'flexible', 'on demand'} 
-            },
-            'optional': False,
-            'description': ' Electricity demand of reverse osmosis plant per year.'
+        self.yearly_unstored_power = {
+            '2025': ureg.Quantity(np.array([5.4e8, 3.6e8, 7.2e8]), 'J'),
+            '2024': ureg.Quantity(np.array([1.26e9, 7.2e8, 1.08e9]), 'J'),
         }
-    },
 
-    'Reactor Baggies': {
-        'Number': {
-            'Value': {
-                'type': {int},
-            },
-            'Unit': 'dimensionless', 
-            'optional': False,
-            'description': ' Number of ports per baggie.'
-        }
-    },    
+        self.total = ureg.Quantity(1000.0, 'USD')
 
-    'Planned Replacement': {
-        'Planned Replacement Baggie': {
-            'Cost_Value': {
-                'type': {float},
-            },
-            'Cost_Unit': 'USD',
-            'Frequency_Value': {
-                'type': {float},
-            },
-            'Frequency_Unit': 'year', # keeping years here, it seems more coherent              
-            'optional': False,
-            'description': ' Replacement frequency and cost of baggies', 
-        }, 
-        'Electrolyzer Stack Replacement': {
-            'Frequency_Value': {
-                'type': {float},
-            },
-            'Frequency_Unit': 'year', # keeping years here, it seems more coherent              
-            'optional': False, 
-            'description': 'Frequency of electrolyzer stack replacements, calculated from replacement time and hourly irradiation data', 
-            'add_processed' = False,  # when add_processed and insert_path are different from the default value, the output resolver must read it from output_dict to inform the 'insert' method accordingly
-            'insert_path' = False
-        },            
-    },       
-}
+        self.h2_production = ureg.Quantity(np.array([0., 955.95413492, 952.47095234, 948.98391499]), 'kg/day')
+
+        self.electricity_demand = ureg.Quantity(np.array([1.3e9, 1.e9]), 'J')
+
+        self.baggie_number = ureg.Quantity(5, 'dimensionless')
+
+        self.baggies_cost = ureg.Quantity(1000, 'USD')
+
+        self.baggie_frequency = ureg.Quantity(5, 'year')
+
+        self.replacement_frequency = ureg.Quantity(10, 'year')
+
+        # the next two ones are not normally self.XXX, but as mentioned earlier I think we need to convert them into self.XXX for the output resolver to work 
+        self.direct_inflated = ureg.Quantity(2000.0, 'USD')
+
+        self.scaling_ratio = ureg.Quantity(1.0, 'dimensionless')
+
+        output_resolver(dcf, 'Power Generation', 'Stored Energy (daily)', 'Value', self, print_info = print_info) # self contains output_dict normally, so inside output_resolver we will call it 
+        output_resolver(dcf, 'Power Generation', 'Available Energy (daily)', 'Value', self, print_info = print_info)
+        output_resolver(dcf, 'Dummy left Direct Capital Cost dummy right', 'Summed Total', 'Value', self, print_info = print_info)
+        output_resolver(dcf, 'Direct Capital Costs', 'Inflated', 'Value', self, print_info = print_info)
+        output_resolver(dcf, 'Technical Operating Parameters and Specifications', 'Plant design flowrate', 'Value', self, print_info = print_info)
+        output_resolver(dcf, 'Technical Operating Parameters and Specifications', 'Scaling Ratio', 'Value', self, print_info = print_info)
+        output_resolver(dcf, 'Scaling', 'Capital Scaling Factor', 'Value', self, print_info = print_info)
+        output_resolver(dcf, 'Power Consumption', 'Reverse Osmosis Consumption (yearly)', 'Value', self, print_info = print_info)
+        output_resolver(dcf, 'Reactor Baggies', 'Number', 'Value', self, print_info = print_info)
+        output_resolver(dcf, 'Planned Replacement', 'Planned Replacement Baggie', 'Cost_Value', self, print_info = print_info)
+        output_resolver(dcf, 'Planned Replacement', 'Planned Replacement Baggie', 'Frequency_Value', self, print_info = print_info)
+        output_resolver(dcf, 'Planned Replacement', 'Planned Replacement Catalyst', 'Frequency_Value', self, print_info = print_info)
+        output_resolver(dcf, 'Planned Replacement', 'Electrolyzer Stack Replacement', 'Frequency_Value', self, print_info = print_info)
+        
 
 
 # Expected final state, that is: what dcf.inp would look like after insertions
@@ -270,8 +236,8 @@ resolved_dict_expected = {
             'Processed': 'Yes'
         },                
         'Summed Total': { # new mid key
-            'Value': 1000.0, 
-            'Unit': 'USD', 
+            'Value': ureg.Quantity(1000.0, 'USD'), 
+            # when we insert a pint quantity, there's no need to insert a 'unit' bottom key
             'Processed': 'Yes'            
         }        
     }, 
@@ -279,47 +245,43 @@ resolved_dict_expected = {
     'Power Generation': { # upper key existed already
         'Available Energy (daily)': { # Value that was initially present, and has been modified
             'Value': {
-                '2025':np.array([5.4e8, 3.6e8, 7.2e8]), 
-                '2024':np.array([1.26e9, 7.2e8, 1.08e9]) 
+                '2025':ureg.Quantity(np.array([5.4e8, 3.6e8, 7.2e8]), 'J'), 
+                '2024':ureg.Quantity(np.array([1.26e9, 7.2e8, 1.08e9]), 'J') 
             }, 
-            'Unit': 'J', 
+            # when we discussed we said we would ignore the 'Unit' if the 'Value' is a pint ; 
+            # I would advise further that when we update a value with a pint quantity, it would be good to remove the existing 'Unit' bottom key from the dict to prevent any issue and unnecessary/wrong item (I hope it should not be too complicated too implement) 
             'Processed': 'Yes'            
         }, 
         'Stored Energy (daily)': { # Value that has been inserted
             'Value': {
-                np.int64(0): np.array([0, 0, 938736, 0, 1008000]), 
-                np.int64(1): np.array([0, 0, 933840, 0, 1005480]), 
+                np.int64(0): ureg.Quantity(np.array([0, 0, 938736, 0, 1008000]), 'J'), 
+                np.int64(1): ureg.Quantity(np.array([0, 0, 933840, 0, 1005480]), 'J'), 
             }, 
-            'Unit': 'J', 
             'Processed': 'Yes'            
         }        
     }, 
 
     'Direct Capital Costs': { # upper key didn't exist in the initial dictionary
         'Inflated': {
-            'Value': 2000.0, 
-            'Unit': 'USD', 
+            'Value': ureg.Quantity(2000.0, 'USD'), 
             'Processed': 'Yes'            
         }
     }, 
 
     'Technical Operating Parameters and Specifications': { 
-        'Plant Design Capacity (Daily)': {
-            'Value': np.array([0., 955.95413492, 952.47095234, 948.98391499]), 
-            'Unit': 'kg', 
+        'Plant design flowrate': {
+            'Value': ureg.Quantity(np.array([0., 955.95413492, 952.47095234, 948.98391499]), 'kg/day'), 
             'Processed': 'Yes'            
         },
         'Scaling Ratio': { # inserted optional value
-            'Value': 1.0, 
-            'Unit': 'dimensionless',  
+            'Value': ureg.Quantity(1.0, 'dimensionless'),
             'Processed': 'Yes'
         }        
     }, 
 
     'Power Consumption': {
         'Reverse Osmosis Consumption (yearly)': {
-            'Value': np.array([1.3e9, 1.e9]),
-            'Unit': 'J',
+            'Value': ureg.Quantity(np.array([1.3e9, 1.e9]), 'J'),
             'Type': 'flexible', 
             'Processed': 'Yes'
         }
@@ -327,36 +289,42 @@ resolved_dict_expected = {
 
     'Reactor Baggies': {
         'Number': {
-            'Value': 5,
-            'Unit': 'dimensionless',
+            'Value': ureg.Quantity(5, 'dimensionless'),
             'Processed': 'Yes'
         }
     },   
 
     'Planned Replacement': {
         'Planned Replacement Baggie': {
-            'Cost_Value': 1000,
-            'Cost_Unit': 'USD',
-            'Frequency_Value': 2,
-            'Frequency_Unit': 'year',
+            'Cost_Value': ureg.Quantity(1000, 'USD'),
+            'Frequency_Value': ureg.Quantity(5, 'year'),
             'Processed': 'Yes'
         }, 
+        'Planned Replacement Catalyst': {
+            'Frequency_Value': ureg.Quantity(1.57788E8, 's'),
+            'Processed': 'Yes'
+        },
         'Electrolyzer Stack Replacement': {
             'Cost_Value': 0.4,
-            'Cost_Unit': 'USD',             
-            'Path': 'Direct Capital Costs - Electrolyzer > Electrolyzer CAPEX ($/kW) > Value', 
+            'Cost_Unit': 'USD',  
+            'Path': 'Direct Capital Costs - Electrolyzer > Electrolyzer CAPEX ($/kW) > Value', # insert_part is False so the path stays as is
             'Comment': 'Based on Chang 2020',
-            'Frequency_Value': np.float64(10.0),
-            'Frequency_Unit': 'year'
+            'Frequency_Value': ureg.Quantity(10, 'year'),
         },          
-    },   
+    }, 
+    'Catalyst': {
+        'Lifetime': {
+            'Value': 0.5,
+            'Unit': 'year', 
+        },      
 
+    }
 }
 
 
-class TestOutputResolver:
 
-    ABS_TOL = 1e-9
+class TestDummyPlugin(unittest.TestCase):
+    ABS_TOL = 1e-12
 
     def _assert_resolved_equal(self, actual, expected) -> None:
         if isinstance(expected, dict):
@@ -380,33 +348,27 @@ class TestOutputResolver:
             assert actual == pytest.approx(expected, abs=self.ABS_TOL)
             return
 
+        elif hasattr(expected, 'units') and hasattr(actual, 'units'):
+            # Compare pint quantities
+            assert abs(actual.magnitude - expected.magnitude) < self.ABS_TOL
+            assert str(actual.units) == str(expected.units)
+            return
+
         else:
             assert actual == expected
             return
 
-    def _apply_values(self, dcf):
-        """Simulate plugin behavior: we would manually specify, in the output_resolver call, in which dict location (keys) to insert a self.XXX value"""
-        for top_key, mid_dict in values_to_insert.items():
-            for mid_key, leaf_dict in mid_dict.items():
-                for leaf_key, value_to_insert in leaf_dict.items():
-                    output_resolver(
-                        dcf,
-                        top_key,
-                        mid_key,
-                        leaf_key,
-                        value_to_insert,
-                        output_dict
-                    )
-
-    def test_output_resolver(self):
+    def test_plugin_resolves_dict_correctly(self):
+        # Create dummy DCF
         dcf = DummyDCF()
-
-        # apply all insertions one by one
-        self._apply_values(dcf)
-
-        # check final state
+        
+        # Run the plugin
+        plugin = DummyPlugin(dcf, print_info=False)
+        
+        # Compare the final dict
         self._assert_resolved_equal(dcf.inp, resolved_dict_expected)
 
 
-if __name__ == '__main__':
-    pytest.main([__file__, '-v'])
+# Run the test
+if __name__ == "__main__":
+    unittest.main(argv=[''], exit=False)

--- a/src/tests/Utilities/output_resolver/output_resolver_test_data.py
+++ b/src/tests/Utilities/output_resolver/output_resolver_test_data.py
@@ -7,6 +7,100 @@ from pyH2A.Utilities.input_modification output_resolver
 ureg = UnitRegistry()
 ureg.define('USD = [currency]')
 
+# Output schema (output equivalent to input_dict)
+output_dict = { 
+    'Power Generation': {
+        'Stored Energy (daily)': { # new middle key to insert
+            'Value': 'self.yearly_recovered_power',
+            'add_processed' : True,  # This is the default so shouldn't be needed anyway, but it doesn't harm to test the explicit specification of it
+            'insert_path' : True,            
+            'description': 'Electricity stored in battery daily (dictionary of years)',
+            'optional': False,            
+        }, 
+        'Available Energy (daily)': { # overwrite existing value
+            # From now on, I don't add 'add_processed' and 'insert_path' when they are true, it's the default so normally it'S unnecessary
+            'Value': 'self.yearly_unstored_power', 
+            'description': 'Available Electricity, daily basis, dictionary of years - energy which has not been stored in battery',
+            'optional': False,            
+        }        
+    }, 
+
+    '<...> Direct Capital Cost <...>': { # actually I'm confused about this one, the docstring says we insert [...] Direct Capital Cost [...] > Summed Total > Value, but I don't find such an insert. So I use it here for the test as an example anyway but in the capital cost plugin we might need to clarify it
+        'Summed Total': {
+            'Value': 'self.total',
+            'description': 'Summed total for each individual table in "Direct Capital Cost" group.', 
+            'optional': False,
+        }
+    }, 
+
+    'Direct Capital Costs': {
+        'Inflated': {
+            'Value': 'self.direct_inflated', # this one is not normally a self.XXX, but if we don't turn it into a self.XXX I suspect it won't work
+            'description': 'Total direct capital costs multiplied by combined inflator.', 
+            'optional': False,            
+        }
+    },    
+
+    'Technical Operating Parameters and Specifications': { 
+        'Plant design flowrate': {# I renamed the existing Plant Design Capacity (kg of H2/day)
+            'Value': 'self.h2_production', #originally there's a division by 365 that iswill require update in the plugin
+            'description': 'Plant design capacity expressed as a daily flowrate, calculated from installed electrolysis power capacity and hourly power generation data.', 
+            'optional': False,
+        },
+        'Scaling Ratio': { # optional
+            'Value': 'self.scaling_ratio', # isn't normally a "self"
+            'description': 'Returned if New Plant Design Capacity was specified.', 
+            'optional': True,            
+        }        
+    },  
+
+    'Scaling': { # this one is optional, and we actually don't insert any value (to check the ability of the output resolver to handle an optional value that is absent)
+        'Capital Scaling Factor': {
+            'Value': 'self.capital_scaling_factor',
+            'description': 'Returned if scaling is active (`Scaling Ratio` or `New Plant Design Capacity (kg of H2/day)` specified).', 
+            'optional': True,            
+        }
+    },
+
+    'Power Consumption': {
+        'Reverse Osmosis Consumption (yearly)': {
+            'Value': 'self.electricity_demand',
+            'Type': 'flexible', # no need to have the intermediate "options" key anymore: in the same way as we define here the inserted variables, we define directly the Type
+            'description': ' Electricity demand of reverse osmosis plant per year.',      
+            'optional': False,                   
+        }
+    },
+
+    'Reactor Baggies': {
+        'Number': {
+            'Value': 'self.baggie_number',
+            'description': 'Number of individual baggies required for design H2 production capacity', 
+            'optional': False,            
+        }
+    },    
+
+    'Planned Replacement': {
+        'Planned Replacement Baggie': {
+            'Cost_Value': 'self.baggies_cost',
+            'Frequency_Value': 'self.baggie_frequency',
+            'description': ' Replacement frequency and cost of baggies',             
+            'optional': False,                
+        }, 
+        'Planned Replacement Catalyst': {
+            'Frequency_Value': 'self.input_dict_resolved["Catalyst"]["Lifetime"]["Value"]', # interesting because in the existing version we insert something that should already be in the dictionary ('dcf.inp['Catalyst']['Lifetime']['Value']'), not a variable that results from a calculation
+                                                                                # rather than picking up the value from dcf.inp (as we currently do), it's better to now pick it up from the resolved dict so we know already it's "clean"        
+            'description': 'Replacement frequency of catalyst in years, identical to catalyst lifetime.', 
+            'optional': False,             
+        },           
+        'Electrolyzer Stack Replacement': {
+            'Frequency_Value': 'self.replacement_frequency',
+            'description': 'Frequency of electrolyzer stack replacements, calculated from replacement time and hourly irradiation data', 
+            'optional': False,             
+            'add_processed' : False,  # when add_processed and insert_path are different from the default value, the output resolver must read it from output_dict to inform the 'insert' method accordingly
+            'insert_path' : False
+        },            
+    },       
+}
 
 class DummyDCF:
     def __init__(self):
@@ -63,100 +157,6 @@ class DummyDCF:
 
 # we need a dummy plugin to contain the variables to insert
 class DummyPlugin:
-    # Output schema (output equivalent to input_dict)
-    output_dict = { 
-        'Power Generation': {
-            'Stored Energy (daily)': { # new middle key to insert
-                'Value': 'self.yearly_recovered_power',
-                'add_processed' : True,  # This is the default so shouldn't be needed anyway, but it doesn't harm to test the explicit specification of it
-                'insert_path' : True,            
-                'description': 'Electricity stored in battery daily (dictionary of years)',
-                'optional': False,            
-            }, 
-            'Available Energy (daily)': { # overwrite existing value
-                # From now on, I don't add 'add_processed' and 'insert_path' when they are true, it's the default so normally it'S unnecessary
-                'Value': 'self.yearly_unstored_power', 
-                'description': 'Available Electricity, daily basis, dictionary of years - energy which has not been stored in battery',
-                'optional': False,            
-            }        
-        }, 
-    
-        '<...> Direct Capital Cost <...>': { # actually I'm confused about this one, the docstring says we insert [...] Direct Capital Cost [...] > Summed Total > Value, but I don't find such an insert. So I use it here for the test as an example anyway but in the capital cost plugin we might need to clarify it
-            'Summed Total': {
-                'Value': 'self.total',
-                'description': 'Summed total for each individual table in "Direct Capital Cost" group.', 
-                'optional': False,
-            }
-        }, 
-
-        'Direct Capital Costs': {
-            'Inflated': {
-                'Value': 'self.direct_inflated', # this one is not normally a self.XXX, but if we don't turn it into a self.XXX I suspect it won't work
-                'description': 'Total direct capital costs multiplied by combined inflator.', 
-                'optional': False,            
-            }
-        },    
-
-        'Technical Operating Parameters and Specifications': { 
-            'Plant design flowrate': {# I renamed the existing Plant Design Capacity (kg of H2/day)
-                'Value': 'self.h2_production', #originally there's a division by 365 that iswill require update in the plugin
-                'description': 'Plant design capacity expressed as a daily flowrate, calculated from installed electrolysis power capacity and hourly power generation data.', 
-                'optional': False,
-            },
-            'Scaling Ratio': { # optional
-                'Value': 'self.scaling_ratio', # isn't normally a "self"
-                'description': 'Returned if New Plant Design Capacity was specified.', 
-                'optional': True,            
-            }        
-        },  
-
-        'Scaling': { # this one is optional, and we actually don't insert any value (to check the ability of the output resolver to handle an optional value that is absent)
-            'Capital Scaling Factor': {
-                'Value': 'self.capital_scaling_factor',
-                'description': 'Returned if scaling is active (`Scaling Ratio` or `New Plant Design Capacity (kg of H2/day)` specified).', 
-                'optional': True,            
-            }
-        },
-
-        'Power Consumption': {
-            'Reverse Osmosis Consumption (yearly)': {
-                'Value': 'self.electricity_demand',
-                'Type': 'flexible', # no need to have the intermediate "options" key anymore: in the same way as we define here the inserted variables, we define directly the Type
-                'description': ' Electricity demand of reverse osmosis plant per year.',      
-                'optional': False,                   
-            }
-        },
-
-        'Reactor Baggies': {
-            'Number': {
-                'Value': 'self.baggie_number',
-                'description': 'Number of individual baggies required for design H2 production capacity', 
-                'optional': False,            
-            }
-        },    
-
-        'Planned Replacement': {
-            'Planned Replacement Baggie': {
-                'Cost_Value': 'self.baggies_cost',
-                'Frequency_Value': 'self.baggie_frequency',
-                'description': ' Replacement frequency and cost of baggies',             
-                'optional': False,                
-            }, 
-            'Planned Replacement Catalyst': {
-                'Frequency_Value': 'self.input_dict_resolved["Catalyst"]["Lifetime"]["Value"]', # interesting because in the existing version we insert something that should already be in the dictionary ('dcf.inp['Catalyst']['Lifetime']['Value']'), not a variable that results from a calculation
-                                                                                    # rather than picking up the value from dcf.inp (as we currently do), it's better to now pick it up from the resolved dict so we know already it's "clean"        
-                'description': 'Replacement frequency of catalyst in years, identical to catalyst lifetime.', 
-                'optional': False,             
-            },           
-            'Electrolyzer Stack Replacement': {
-                'Frequency_Value': 'self.replacement_frequency',
-                'description': 'Frequency of electrolyzer stack replacements, calculated from replacement time and hourly irradiation data', 
-                'optional': False,             
-                'add_processed' : False,  # when add_processed and insert_path are different from the default value, the output resolver must read it from output_dict to inform the 'insert' method accordingly
-                'insert_path' : False
-            },            
-        },       
-    }
 
     def __init__(self, dcf, print_info):
         self.input_dict_resolved = { # sometimes we need to pick up some values from the resolved dict that exists in the plugin, that is created after the input_resolver calls
@@ -195,20 +195,8 @@ class DummyPlugin:
 
         self.scaling_ratio = ureg.Quantity(1.0, 'dimensionless')
 
-        output_resolver(dcf, 'Power Generation', 'Stored Energy (daily)', 'Value', self, print_info = print_info) # self contains output_dict normally, so inside output_resolver we will call it 
-        output_resolver(dcf, 'Power Generation', 'Available Energy (daily)', 'Value', self, print_info = print_info)
-        output_resolver(dcf, 'Dummy left Direct Capital Cost dummy right', 'Summed Total', 'Value', self, print_info = print_info)
-        output_resolver(dcf, 'Direct Capital Costs', 'Inflated', 'Value', self, print_info = print_info)
-        output_resolver(dcf, 'Technical Operating Parameters and Specifications', 'Plant design flowrate', 'Value', self, print_info = print_info)
-        output_resolver(dcf, 'Technical Operating Parameters and Specifications', 'Scaling Ratio', 'Value', self, print_info = print_info)
-        output_resolver(dcf, 'Scaling', 'Capital Scaling Factor', 'Value', self, print_info = print_info)
-        output_resolver(dcf, 'Power Consumption', 'Reverse Osmosis Consumption (yearly)', 'Value', self, print_info = print_info)
-        output_resolver(dcf, 'Reactor Baggies', 'Number', 'Value', self, print_info = print_info)
-        output_resolver(dcf, 'Planned Replacement', 'Planned Replacement Baggie', 'Cost_Value', self, print_info = print_info)
-        output_resolver(dcf, 'Planned Replacement', 'Planned Replacement Baggie', 'Frequency_Value', self, print_info = print_info)
-        output_resolver(dcf, 'Planned Replacement', 'Planned Replacement Catalyst', 'Frequency_Value', self, print_info = print_info)
-        output_resolver(dcf, 'Planned Replacement', 'Electrolyzer Stack Replacement', 'Frequency_Value', self, print_info = print_info)
-        
+        output_resolver(dcf.inp, self, output_dict) # we want to call the output_resolver once only
+
 
 
 # Expected final state, that is: what dcf.inp would look like after insertions

--- a/src/tests/Utilities/output_resolver/output_resolver_test_data.py
+++ b/src/tests/Utilities/output_resolver/output_resolver_test_data.py
@@ -1,5 +1,6 @@
 import numpy as np
-from pint import UnitRegistry
+from pint import UnitRegistry, Quantity
+import pytest
 
 ureg = UnitRegistry()
 ureg.define('USD = [currency]')
@@ -310,3 +311,59 @@ resolved_dict_expected = {
 }
 
 
+class TestOutputResolver:
+
+    ABS_TOL = 1e-9
+
+    def _assert_resolved_equal(self, actual, expected) -> None:
+        if isinstance(expected, dict):
+            actual_key_map = {str(key).casefold(): key for key in actual}
+            expected_key_map = {str(key).casefold(): key for key in expected}
+            assert set(actual_key_map.keys()) == set(expected_key_map.keys())
+
+            for normalized_key, expected_key in expected_key_map.items():
+                actual_key = actual_key_map[normalized_key]
+                self._assert_resolved_equal(
+                    actual[actual_key], expected[expected_key]
+                )
+            return
+
+        elif isinstance(expected, np.ndarray):
+            assert isinstance(actual, np.ndarray)
+            assert np.allclose(actual, expected, atol=self.ABS_TOL)
+            return
+
+        elif isinstance(expected, float):
+            assert actual == pytest.approx(expected, abs=self.ABS_TOL)
+            return
+
+        else:
+            assert actual == expected
+            return
+
+    def _apply_values(self, dcf):
+        """Simulate plugin behavior: we would manually in which dict location to insert a self.XXX value"""
+        for top_key, mid_dict in values_to_insert.items():
+            for mid_key, leaf_dict in mid_dict.items():
+                for leaf_key, value in leaf_dict.items():
+                    output_resolver(
+                        dcf,
+                        top_key,
+                        mid_key,
+                        leaf_key,
+                        value,
+                        output_dict
+                    )
+
+    def test_output_resolver(self):
+        dcf = DummyDCF()
+
+        # apply all insertions one by one
+        self._apply_values(dcf)
+
+        # check final state
+        self._assert_resolved_equal(dcf.inp, resolved_dict_expected)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION

# Description

The output resolver data set is not quite "symmetrical" to the input resolver side.
On the output side, there exists an initial dictionary, which contains various values. The output resolver will have to insert or update values in this dict. Therefore we define:
- the initial state of the dictionary in class DummyDCF.
- a dummy plugin 'DummyPlugin' is created, in which the output_dict is defined, and the variables that will be inserted are assigned a value (pint quantities)
- the output_dict structure contains all the needed information: for each key set where a value has to be inserted, we specify the variable to insert (under the form of a string: the output resolver will have to extract the corresponding variable), but also the data such as 'description', 'optional' etc. Note that 'add_processed' and 'insert_path' are normally not needed when they are True, as this is the default anyway.
- At the end of the dummy plugin, we call the output resolver once for all.
- after insertion the dictionary should be like 'resolved_dict_expected'. 
- A testing code proposal that would call the dummy plugin, then asserts if the resulting dict matches the expected one.

Contrary to the previous version, where the value to insert was an argument of the output_resolver call, we now want the variable to insert to be specified in the output_dict. 
So the output_dict call arguments are now 'dcf.inp, 'self' (which contains the output_dict as well as the variables to insert) and 'output_dict'.
- This creates an extra difficulty: normally not all the variables to insert are self.XXX. But since we don't pass the variable to insert as an argument to output_resolver anymore, I don't see any other solution but to force all the variables to be self.XXX. Otherwise, the output_resolver wouldn't find them. (and if we kept on passing the variable to insert as an argument, then what would be the point of mentioning it in the output_dict?).



[OLD DESCRIPTION]
The output resolver data set is not quite "symmetrical" to the input resolver side.
On the output side, there exists an initial dictionary, which contains various values. The output resolver will have to insert or update values in this dict. Therefore we define:
- the initial state of the dictionary in class DummyDCF.
- the values that will have to be inserted in values_to_insert. I chose to introduce a "values_to_insert" dictionary structure because it is certainly more convenient for the testing side (which is the point here); although of course, in the plugins, we would insert "self.XXX" rather than "values_to_insert['top']['mid']['bottom']". Note that the values_to_insert dictionary contains pint quantities, since this is what we will end-up handling: the goal is to check the output resolver's ability to insert correctly the magnitude and unit of those pint quantities.
- the output_dict, that is: the structure of the data to be inserted. As mentioned in the comment, I chose not to introduce a 'dimension' (this is relevant on the input resolver side to validate the dimension vs unit, but on the output side I don't think it's useful) ; I however introduces a 'Unit', I'm not 100% sure if this is a good idea or not: in principle we can get the unit from the pint quantity, but I thought we might want to have a consistency check between the expected unit (as per the structure) and the one that is returned due to the pint quantity. The output_dict also specifies when 'add_processed' and 'insert_path' are not at their default values, so the output_resolver can be informed of it.
- what the dictionary should be after insertion ('resolved_dict_expected'). This post-insertion dictionary should of course have strictly the same structure as the input dict we have on the input resolver side.

- Edit 27/03: added a proposal of how the test data could be used

# Motivation / Background
This stucture will serve as a template, as well as a way to test, the future output resolver

# Related Issue(s)
input resolver test data: https://github.com/water-splitting-group/pyH2A/pull/8

# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [X] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change
etc

# How Has This Been Tested?
Not tested yet: it will constitute the basis for the testing of the output resolver

# Checklist
- [X] Code follows pyH2A style guidelines
- [X] Self-review of code completed
- [X] Comments added in complex or critical sections

