### PR TITLE
Refactor: Remove solar concentrator from Pec Plugin - c8s65gxjrsjgb3brm8im6h9c74c

### DIFF
--- a/src/pyH2A/Plugins/PEC_Plugin.py
+++ b/src/pyH2A/Plugins/PEC_Plugin.py
@@ -27,9 +27,6 @@ class PEC_Plugin:
 		Solar-to-hydrogen efficiency in percentage or as a value between 0 and 1.
 	Solar Input > Mean solar input (kWh/m2/day) > Value : float
 		Mean solar input in kWh/m2/day, ``process_table()`` is used.
-	Solar Concentrator > Concentration Factor > Value : float, optional
-		Concentration factor created by solar concentration module, which is used in combination
-		with PEC cells. If "Solar Concentrator" is in dcf.inp, ``process_table()`` is used.
 
 	Returns
 	-------
@@ -48,9 +45,6 @@ class PEC_Plugin:
 	'''
 
 	def __init__(self, dcf, print_info):
-		if 'Solar Concentrator' in dcf.inp:
-			process_table(dcf.inp, 'Solar Concentrator', 'Value')
-
 		process_table(dcf.inp, 'Solar Input', 'Value')
 		process_table(dcf.inp, 'Solar-to-Hydrogen Efficiency', 'Value')
 		process_table(dcf.inp, 'PEC Cells', 'Value')

--- a/src/tests/plugins/pec_plugin_test.py
+++ b/src/tests/plugins/pec_plugin_test.py
@@ -17,9 +17,7 @@ class DummyDCF:
         south_spacing,
         east_spacing,
         sth,
-        solar_input,
-        conc_factor,
-        
+        solar_input,        
     ):
         self.inp = {
             "Technical Operating Parameters and Specifications": {
@@ -42,9 +40,6 @@ class DummyDCF:
             "Solar Input": {
                 "Mean solar input (kWh/m2/day)": {"Value": solar_input}
             },
-            "Solar Concentrator": {
-                "Concentration Factor": {"Value": conc_factor},
-            },
         }
 
 
@@ -63,7 +58,6 @@ class DummyDCF:
                 "east_spacing": 17.3,
                 "sth": 0.14,
                 "solar_input": 5.0,
-                "conc_factor": 50,
             },
             "expected": {
                 "total_land_area_acres": 1321.7195315319523,


### PR DESCRIPTION
# Description

This PR removes the solar concentrator component from the PEC plugin. The functionality is redundant, as a dedicated plugin for solar concentrators already exists.

The change simplifies the PEC plugin and avoids duplication of logic across the codebase.

# Motivation / Background

* The PEC plugin currently includes solar concentrator functionality that overlaps with an existing standalone plugin.
* Maintaining duplicate implementations increases complexity and the risk of inconsistencies.
* As noted by Jacob, this functionality should be handled exclusively by the dedicated solar concentrator plugin.

This change improves modularity and aligns with pyH2A’s plugin design philosophy.


# Type of Change


* [ ] Bug fix (non-breaking change)
* [ ] New feature (non-breaking)
* [x] Breaking change (affects existing behavior)
* [ ] Documentation update
* [ ] Test addition or update
* [x] Design / Architecture change

# How Has This Been Tested?

* [x] Unit tests
* [ ] Integration tests
* [ ] Performance tests
* [ ] Manual tests / example model runs

# Checklist

* [x] Code follows pyH2A style guidelines
* [x] Self-review of code completed
* [x] Comments added in complex or critical sections
* [ ] Documentation updated (docstrings, README, ReadTheDocs)
* [ ] Example input YAML or scripts updated if relevant
* [x] No new warnings generated
* [ ] Tests added / updated and passing
* [ ] Dependent changes merged and published
