### PR TITLE
Input resolver fails when input is a dictionary of Quantity objects

### DIFF
--- a/src/pyH2A/Utilities/IO/input_resolver.py
+++ b/src/pyH2A/Utilities/IO/input_resolver.py
@@ -283,6 +283,20 @@ def value_with_unit_resolver_function(top_key,
                                     bottom_key_group[0],)
         
         return value_retrieved
+    
+    elif isinstance(value_retrieved, dict) and all(isinstance(value, Quantity) for value in value_retrieved.values()):
+        unit_specification = row_dict[bottom_key_group[1]]
+
+        for quantity in value_retrieved.values():
+            _perform_checks_on_quantity(
+                quantity,
+                value_specification,
+                unit_specification,
+                top_key,
+                middle_key,
+                bottom_key_group[0],
+            ) 
+        return value_retrieved    
 
     # If retrieved value is numerical, quantity object is created, 
     # checks are performed and newly created quantity object is returned

--- a/src/pyH2A/Utilities/IO/input_resolver.py
+++ b/src/pyH2A/Utilities/IO/input_resolver.py
@@ -247,23 +247,6 @@ def value_resolver_function(top_key,
         return value_specification, value_retrieved
     else:
         return value_retrieved
-            
-def unit_resolver_function(top_key, 
-                           middle_key, 
-                           bottom_key, 
-                           row_dict, 
-                           dcf_class):
-    '''
-    Resolve unit
-    '''
-    
-    unit_specification, unit_retrieved = _get_specification_and_retrieved_value(top_key,
-                                                                               middle_key,
-                                                                               bottom_key,
-                                                                               row_dict,
-                                                                               dcf_class)
-    
-    return unit_specification, unit_retrieved
      
 def value_with_unit_resolver_function(top_key, 
                                       middle_key, 

--- a/src/pyH2A/Utilities/IO/input_resolver.py
+++ b/src/pyH2A/Utilities/IO/input_resolver.py
@@ -154,6 +154,19 @@ def _create_quantity_and_validate(value_retrieved,
             )
         return processed_dict
 
+    # Existing Quantity: validate only
+    elif isinstance(value_retrieved, Quantity):
+        _perform_checks_on_quantity(
+            value_retrieved,
+            value_specification,
+            unit_specification,
+            top_key,
+            middle_key,
+            bottom_key
+        )
+
+        return value_retrieved
+    
     # Upon finding numerical values, run our processing
     elif isinstance(value_retrieved, (float, int, np.ndarray)):
         # 1. Create Quantity object
@@ -284,29 +297,14 @@ def value_with_unit_resolver_function(top_key,
         
         return value_retrieved
     
-    elif isinstance(value_retrieved, dict) and all(isinstance(value, Quantity) for value in value_retrieved.values()):
-        unit_specification = row_dict[bottom_key_group[1]]
-
-        for quantity in value_retrieved.values():
-            _perform_checks_on_quantity(
-                quantity,
-                value_specification,
-                unit_specification,
-                top_key,
-                middle_key,
-                bottom_key_group[0],
-            ) 
-        return value_retrieved    
-
     # If retrieved value is numerical, quantity object is created, 
     # checks are performed and newly created quantity object is returned
     elif isinstance(value_retrieved, (int, float, np.ndarray, dict)):
 
-        unit_specification, unit_retrieved = unit_resolver_function(top_key, 
-                                                                    middle_key, 
-                                                                    bottom_key_group[1], 
-                                                                    row_dict, 
-                                                                    dcf_class)
+        unit_specification = row_dict[bottom_key_group[1]]
+
+        # Only try to get Unit from dcf.inp if it exists
+        unit_retrieved = dcf_class.inp[top_key][middle_key].get(bottom_key_group[1], None)
 
 
         # Create quantities and check them based on specifications 

--- a/src/tests/Utilities/Input_Resolver/input_resolver_test_data.py
+++ b/src/tests/Utilities/Input_Resolver/input_resolver_test_data.py
@@ -78,8 +78,9 @@ class DummyDCF:
             'Power Generation': {
                 'Available Power': {
                     'Value': {
-                        '2025':Quantity(np.array([400.*3600, 250.*3600, 350.*3600]), 'kJ'), '2024':Quantity(np.array([500., 350., 450.]), 'kWh')
+                        '2025':Quantity(np.array([400.*3600, 250.*3600, 350.*3600]), 'kJ'), '2024':np.array([500., 350., 450.])
                     }, 
+                    'Unit': 'kWh',                    
                     'Processed': True
                 },
                 'Stored Power': {

--- a/src/tests/Utilities/Input_Resolver/input_resolver_test_data.py
+++ b/src/tests/Utilities/Input_Resolver/input_resolver_test_data.py
@@ -78,9 +78,8 @@ class DummyDCF:
             'Power Generation': {
                 'Available Power': {
                     'Value': {
-                        '2025':np.array([400., 250., 350.]), '2024':np.array([500., 350., 450.])
+                        '2025':Quantity(np.array([400.*3600, 250.*3600, 350.*3600]), 'kJ'), '2024':Quantity(np.array([500., 350., 450.]), 'kWh')
                     }, 
-                    'Unit': 'kWh',
                     'Processed': True
                 },
                 'Stored Power': {


### PR DESCRIPTION
# checks iterate over Quantities nested in a dict 

# Description
- Add an elif statement in create_quantity_and_validate to return Quantities directly, and modify the elif isinstance(value_retrieved, (int, float, np.ndarray, dict)) case in value_with_unit_resolver_function to treat separately the retrieval of the unit_specification and of the unit_retrieved
- modify input_resolver_test_data.py to test the case when the input is a dict of Quantity objects + non-Quantity (with unit applying to it), and with two different units

# Motivation / Background
- input resolver didn't accept quantities in dicts



# Type of Change
Please check all that apply:
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change


# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [x] Manual tests / example model runs

## Test Details:
run input_resolver.py from 'src\tests\Utilities\Input_Resolver'

# Checklist
- [x] Code follows pyH2A style guidelines
- [x] Self-review of code completed
- [ ] Comments added in complex or critical sections: NA
- [ ] Documentation updated (docstrings, README, RedTheDocs) : NA
- [ ] Example input YAML or scripts updated if relevant: NA
- [x] No new warnings generated
- [x] Tests added / updated and passing
- [ ] Dependent changes merged and published: NA

