### PR TITLE
PR to expand or correct units of measurement if necessary

### DIFF
--- a/src/pyH2A/Utilities/Unit_Handler/config.py
+++ b/src/pyH2A/Utilities/Unit_Handler/config.py
@@ -72,7 +72,7 @@ DIMENSIONS = {
             "mm3": 1e-9,
             "cm3": 1e-6,
             "L": 1e-3,
-            "liters": 1e-3,
+            "liter": 1e-3,
             "km3": 1e9,
             "mL": 1e-6,
             "uL": 1e-9

--- a/src/pyH2A/Utilities/Unit_Handler/config.py
+++ b/src/pyH2A/Utilities/Unit_Handler/config.py
@@ -3,6 +3,8 @@ Configuration for the custom pyH2A lightweight unit handler.
 Defines supported dimensions, base units, and conversions.
 """
 
+from scipy import constants as con
+
 # Temperature handles as a special case because of offsets vs multipliers
 ABSOLUTE_TEMPERATURE = {
     "base": "K",
@@ -119,7 +121,7 @@ DIMENSIONS = {
             "mol": 1.0,
             "umol": 1e-6,
             "mmol": 1e-3, 
-            "entity": 1/6.022e23
+            "entity": 1/con.Avogadro
         }
     },
     "voltage": {

--- a/src/pyH2A/Utilities/Unit_Handler/config.py
+++ b/src/pyH2A/Utilities/Unit_Handler/config.py
@@ -118,7 +118,8 @@ DIMENSIONS = {
         "conversions": {
             "mol": 1.0,
             "umol": 1e-6,
-            "mmol": 1e-3
+            "mmol": 1e-3, 
+            "entity": 1/6.022e23
         }
     },
     "voltage": {


### PR DESCRIPTION
# Units of measurement improvement

# Description

- Add "entity" as a unit to the substance, which is necessary when we go from molecule energy to molar energy
- We can use this PR to correct eventual inconsistencies in the current units, for example "liters" is the only unit that is plural (we could change to "liter" for consistency)


# Related Issue(s)
PR53

# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change
etc

# How Has This Been Tested?
NA


# Checklist
- [x] Code follows pyH2A style guidelines
- [x] Self-review of code completed
- [x] No new warnings generated

