### PR TITLE
Refactor: Update the plugin and test - Variable Operating Cost Plugin

### DIFF
--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -8,7 +8,7 @@ input_dict = {
 	"Technical Operating Parameters and Specifications": {
 		"Output per year": {
 			"Value": {
-				"type": {float},
+				"type": {float, np.ndarray},
 				"bounds": (0, None)
 			},
 			"Unit": {
@@ -22,14 +22,16 @@ input_dict = {
 		"<...>": {
 			"Cost_Value": {
 				"type": {float, str, np.ndarray},
-				"bounds": (0, None)
+				"bounds": (0, None),
+				"path": "Cost_Path"
 			},
 			"Cost_Unit": {
 				"dimension": "currency" # we omit the basis on purpose, at it is transparent, and will simplify with the basis per kg; the raito is precisely what the conversion factor is there for
 			},			
 			"Usage_Value": {
 				"type": {float},
-				"bounds": (0, None)
+				"bounds": (0, None), 
+				"path": "Usage_Path"
 			},
 			"Usage_Unit": {
 				"dimension": "dimensionless/mass" # basis per kg of hydrogen
@@ -40,23 +42,15 @@ input_dict = {
 			},
 			"Price_Conversion_Factor_Unit": {
 				"dimension": "dimensionless"
-			},
-			"Cost_Path": {
-				"type": {str},
-				"bounds": None, 
-			},			
-			"Usage_Path": {
-				"type": {str},
-				"bounds": None, 
-			},
+			},		
 			"optional": True,
-			"description": "Utilities are specified by specifying the cost of a given utility (e.g. USD of each kWh of electricity and specifying the usage of the utility per mass of product (e.g. kWh of electricity consumption /kg (H2). The cost of the utility may be either a float, a ndarray with the same length as `dcf.inflation_correction` or a textfile containing cost values (cost values have to be in second column). For cost the path key is Cost_Path and for usage the path key is Usage_Path"
+			"description": "Utilities are specified by specifying the cost of a given utility (e.g. USD of each kWh of electricity) and specifying the usage of the utility per mass of product (e.g. kWh of electricity consumption /kg (H2). The cost of the utility may be either a float, a ndarray with the same length as `dcf.inflation_correction` or a textfile containing cost values (cost values have to be in second column). For cost the path key is Cost_Path and for usage the path key is Usage_Path"
 		}
 	},
 	"<...> Other Variable Operating Cost <...>": {
 		"<...>": {
 			"Value": {
-				"type": {float},
+				"type": {float, np.ndarray},
 				"bounds": (0, None)
 			},
 			"Unit": {
@@ -101,7 +95,7 @@ output_dict = {
 		"Other": {
 			"Value": {
 				"inserted_value": "other",
-				"type": {float},
+				"type": {float, np.ndarray},
 				"dimension": "currency",
 			},
 			"optional": False,
@@ -128,7 +122,6 @@ output_dict = {
                     "description": "Summed total of other variable operating costs across all tables"
                 },
             },
-
 		},
 	}
 }
@@ -179,7 +172,6 @@ class Variable_Operating_Cost_Plugin:
 		self.calculate_utilities_cost(dcf)
 		self.other_variable_costs(dcf)
 		self.total_variable_costs = Quantity(self.utilities.unit['USD'] + self.other.unit['USD'], 'USD')	
-
 		output_inserter_function(output_dict, self, dcf, 'Variable_Operating_Cost_Plugin')   
 
 

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -12,10 +12,10 @@ input_dict = {
 				"bounds": (0, None)
 			},
 			"Unit": {
-				"dimension": "mass / time"
+				"dimension": "mass"
 			},
 			"optional": False,
-			"description": "Yearly output taking operating capacity factor into account, in (kg of H2)/year."
+			"description": "Yearly output taking operating capacity factor into account, in mass of H2"
 		}
 	},
 	"Utilities": {
@@ -115,7 +115,7 @@ class Variable_Operating_Cost_Plugin:
 	Parameters
 	----------
 	Technical Operating Parameters and Specifications > Output per year > Value : float
-		Yearly output taking operating capacity factor into account, in (kg of H2)/year.
+		Yearly output taking operating capacity factor into account, in (kg of H2).
 	Utilities > [...] > Cost : float, ndarray or str
 		Cost of utility (e.g. $/kWh for electricity). May be either a float, a ndarray with the
 		same length as `dcf.inflation_correction` or a textfile containing cost values (cost values 
@@ -163,7 +163,7 @@ class Variable_Operating_Cost_Plugin:
 			utility = Utility(self.input_dict_resolved['Utilities'][key], dcf)
 			self.utilities += utility.cost_per_kg_H2.unit['USD/kg']
 
-		self.utilities = self.utilities * self.input_dict_resolved['Technical Operating Parameters and Specifications']['Output per year']['Value'].unit['kg/year']
+		self.utilities = self.utilities * self.input_dict_resolved['Technical Operating Parameters and Specifications']['Output per year']['Value'].unit['kg']
 		self.utilities = Quantity(self.utilities, 'USD')
 
 	def other_variable_costs(self, dcf, print_info):

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -6,7 +6,7 @@ import numpy as np
 
 input_dict = {	
 	"Technical Operating Parameters and Specifications": {
-		"Output per Year": {
+		"Output per year": {
 			"Value": {
 				"type": {float},
 				"bounds": (0, None)
@@ -25,7 +25,7 @@ input_dict = {
 				"bounds": (0, None)
 			},
 			"Cost_Unit": {
-				"dimension": "currency" # we omit the basis on purpose
+				"dimension": "currency" # we omit the basis on purpose, at it is transparent, and will simplify with the basis per kg; the raito is precisely what the conversion factor is there for
 			},			
 			"Usage_Value": {
 				"type": {float},
@@ -41,13 +41,9 @@ input_dict = {
 			"Price_Conversion_Factor_Unit": {
 				"dimension": "dimensionless"
 			},
-			"Path_Value": {
+			"Usage_Path": {
 				"type": {str},
-				"bounds": None
-			},
-			"Usage_Path_Value": {
-				"type": {str},
-				"bounds": None
+				"bounds": None, 
 			},
 			"optional": True,
 			"description": "Utilities are specified by specifying the cost of a given utility (e.g. $/kWh(electricity) and specifying the usage of the utility per mass of product (e.g. kWh(electricity)/kg(H2). The cost of the utility may be either a float, a ndarray with the same length as `dcf.inflation_correction` or a textfile containing cost values (cost values have to be in second column). For cost the path key is Path and for usage the path key is Usage Path"
@@ -118,20 +114,18 @@ class Variable_Operating_Cost_Plugin:
 
 	Parameters
 	----------
-	Technical Operating Parameters and Specifications > Output per Year > Value : float
+	Technical Operating Parameters and Specifications > Output per year > Value : float
 		Yearly output taking operating capacity factor into account, in (kg of H2)/year.
 	Utilities > [...] > Cost : float, ndarray or str
 		Cost of utility (e.g. $/kWh for electricity). May be either a float, a ndarray with the
 		same length as `dcf.inflation_correction` or a textfile containing cost values (cost values 
 		have to be in second column).
-	Utilities > [...] > Usage per kg H2 : float
-		Usage of utility per kg H2 (e.g. kWh/(kg of H2) for electricity).
-	Utilities > [...] > Price Conversion Factor : float
+	Utilities > [...] > Usage : float
+		Usage of utility per functional unit (e.g. kWh/(kg of H2) for electricity).
+	Utilities > [...] > Price_Conversion_Factor : float
 		Conversion factor between cost and usage units. Should be set to 1 if no conversion is
 		required.
-	Utilities > [...] > Path : str, optional
-		Path for `Cost` entry.
-	Utilities > [...] > Usage Path : str, optional
+	Utilities > [...] > Usage_Path : str, optional
 		Path for `Usage per kg H2` entry.
 	[...] Other Variable Operating Operating Cost [...] >> Value : float
 		``sum_all_tables()`` is used.
@@ -176,9 +170,9 @@ class Variable_Operating_Cost_Plugin:
 		'''Applying ``sum_all_tables()`` to "Other Variable Operating Cost" group.
 		'''
 
-		self.other = dcf.chemical_inflator * sum_all_tables(dcf.inp, 'Other Variable Operating Cost', 'Value', 
+		self.other = dcf.chemical_inflator * sum_all_tables(self.input_dict_resolved, 'Other Variable Operating Cost', 'Value', 
 																insert_total = True, class_object = dcf, 
-																print_info = print_info, unit = 'USD')
+																print_info = print_info, unit = 'USD') # Unit will need to be removed after we correct sum_all_tables
 		self.other = Quantity(self.other, 'USD')
 
 class Utility:
@@ -197,13 +191,13 @@ class Utility:
 		'''Calculation of utility cost per kg of H2 with inflation correction.
 		'''
 		
-		if isinstance(dictionary['Cost'], str):
-			prices = read_textfile(dictionary['Cost'], delimiter = '	')
+		if isinstance(dictionary['Cost_Value'], str):
+			prices = read_textfile(dictionary['Cost_Value'], delimiter = '	')
 			years_idx = fn.find_nearest(prices, dcf.years)
 			prices = prices[years_idx]
 
 			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price Conversion Factor'].unit['-'] * dictionary['Usage'], 'USD/kg') # probleme in this plugin: we don't know the units in advance
 
 		else:
-			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost'].unit['USD'] * dictionary['Usage'].unit['-/kg'] * dictionary['Price Conversion Factor'].unit['-']
+			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost_Value'].unit['USD'] * dictionary['Usage_Value'].unit['-/kg'] * dictionary['Price_Conversion_Factor_Value'].unit['-']
 			self.cost_per_kg_H2 = Quantity(np.ones(len(dcf.inflation_factor)) * annual_cost_per_kg_H2, 'USD/kg')

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -101,7 +101,7 @@ output_dict = {
                     "Value": {
                         "type": {float},
                     },
-                    "optional": True,
+                    "optional": False,
                     "description": "Summed total of other variable operating costs across all tables"
                 },
             },

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -1,4 +1,6 @@
-from pyH2A.Utilities.input_modification import insert, sum_all_tables, process_table, read_textfile
+from pyH2A.Utilities.input_modification import sum_all_tables, read_textfile
+from pyH2A.Utilities.IO import input_resolver_function, output_inserter_function
+from pyH2A.Utilities.Unit_Handler.quantity import Quantity
 import pyH2A.Utilities.find_nearest as fn
 import numpy as np
 
@@ -22,22 +24,28 @@ input_dict = {
 				"type": {float, str, np.ndarray},
 				"bounds": (0, None)
 			},
+			"Cost_Unit": {
+				"dimension": "currency" # we omit the basis on purpose
+			},			
 			"Usage_Value": {
 				"type": {float},
 				"bounds": (0, None)
 			},
-			"Price Conversion Factor Value": {
+			"Usage_Unit": {
+				"dimension": "dimensionless/mass" # basis per kg of hydrogen
+			},			
+			"Price_Conversion_Factor_Value": {
 				"type": {float},
 				"bounds": (0, None)
 			},
-			"Price Conversion Factor Unit": {
+			"Price_Conversion_Factor_Unit": {
 				"dimension": "dimensionless"
 			},
 			"Path_Value": {
 				"type": {str},
 				"bounds": None
 			},
-			"Usage Path Value": {
+			"Usage_Path_Value": {
 				"type": {str},
 				"bounds": None
 			},
@@ -60,14 +68,13 @@ input_dict = {
 	}
 }
 
-
 output_dict = {
     "Variable Operating Costs": {
 		"Total": {
 			"Value": {
-				"inserted_value": "utilities + other",
+				"inserted_value": "total_variable_costs",
 				"type": {float, np.ndarray},
-				"dimension": "currency / time",
+				"dimension": "currency",
 			},
 			"optional": False,
 			"description": "Total variable operating costs, including utilities and other variable operating costs."
@@ -76,7 +83,7 @@ output_dict = {
 			"Value": {
 				"inserted_value": "utilities",
 				"type": {float, np.ndarray},
-				"dimension": "currency / time",
+				"dimension": "currency",
 			},
 			"optional": False,
 			"description": "Total variable operating costs for utilities, including inflation correction."
@@ -85,7 +92,7 @@ output_dict = {
 			"Value": {
 				"inserted_value": "other",
 				"type": {float},
-				"dimension": "currency / time",
+				"dimension": "currency",
 			},
 			"optional": False,
 			"description": "Total variable operating costs for other variable operating costs."
@@ -96,7 +103,7 @@ output_dict = {
             "<...> Other Variable Operating Cost <...>": {
                 "Summed Total": {
                     "Value": {
-                        "type": {int, float},
+                        "type": {float},
                     },
                     "optional": True,
                     "description": "Summed total of other variable operating costs across all tables"
@@ -143,18 +150,14 @@ class Variable_Operating_Cost_Plugin:
 	'''
 
 	def __init__(self, dcf, print_info):
-		process_table(dcf.inp, 'Technical Operating Parameters and Specifications', 'Value')
-		process_table(dcf.inp, 'Utilities', ['Cost', 'Usage per kg H2'], path_key = ['Path', 'Usage Path'])
+		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Variable_Operating_Cost_Plugin')
 
 		self.calculate_utilities_cost(dcf)
 		self.other_variable_costs(dcf, print_info)
+		self.total_variable_costs = Quantity(self.utilities.unit['USD'] + self.other.unit['USD'], 'USD')	
 
-		insert(dcf, 'Variable Operating Costs', 'Total', 'Value', 
-				self.utilities + self.other, __name__, print_info = print_info)
-		insert(dcf, 'Variable Operating Costs', 'Utilities', 'Value', 
-				self.utilities, __name__, print_info = print_info)
-		insert(dcf, 'Variable Operating Costs', 'Other', 'Value', 
-				self.other, __name__, print_info = print_info)
+		output_inserter_function(output_dict, self, dcf, 'Variable_Operating_Cost_Plugin')   
+
 
 	def calculate_utilities_cost(self, dcf):
 		'''Iterating over all utilities and computing summed yearly costs.
@@ -162,11 +165,12 @@ class Variable_Operating_Cost_Plugin:
 
 		self.utilities = 0.
 
-		for key in dcf.inp['Utilities']:
-			utility = Utility(dcf.inp['Utilities'][key], dcf)
-			self.utilities += utility.cost_per_kg_H2
+		for key in self.input_dict_resolved['Utilities']:
+			utility = Utility(self.input_dict_resolved['Utilities'][key], dcf)
+			self.utilities += utility.cost_per_kg_H2.unit['USD/kg']
 
-		self.utilities = self.utilities * dcf.inp['Technical Operating Parameters and Specifications']['Output per Year']['Value']
+		self.utilities = self.utilities * self.input_dict_resolved['Technical Operating Parameters and Specifications']['Output per year']['Value'].unit['kg/year']
+		self.utilities = Quantity(self.utilities, 'USD')
 
 	def other_variable_costs(self, dcf, print_info):
 		'''Applying ``sum_all_tables()`` to "Other Variable Operating Cost" group.
@@ -174,7 +178,8 @@ class Variable_Operating_Cost_Plugin:
 
 		self.other = dcf.chemical_inflator * sum_all_tables(dcf.inp, 'Other Variable Operating Cost', 'Value', 
 																insert_total = True, class_object = dcf, 
-																print_info = print_info)
+																print_info = print_info, unit = 'USD')
+		self.other = Quantity(self.other, 'USD')
 
 class Utility:
 	'''Individual utility objects.
@@ -197,8 +202,8 @@ class Utility:
 			years_idx = fn.find_nearest(prices, dcf.years)
 			prices = prices[years_idx]
 
-			self.cost_per_kg_H2 = prices[:,1] * dcf.inflation_correction * dictionary['Price Conversion Factor'] * dictionary['Usage per kg H2']
+			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price Conversion Factor'].unit['-'] * dictionary['Usage'], 'USD/kg') # probleme in this plugin: we don't know the units in advance
 
 		else:
-			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost'] * dictionary['Usage per kg H2'] * dictionary['Price Conversion Factor']
-			self.cost_per_kg_H2 = np.ones(len(dcf.inflation_factor)) * annual_cost_per_kg_H2
+			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost'].unit['USD'] * dictionary['Usage'].unit['-/kg'] * dictionary['Price Conversion Factor'].unit['-']
+			self.cost_per_kg_H2 = Quantity(np.ones(len(dcf.inflation_factor)) * annual_cost_per_kg_H2, 'USD/kg')

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -64,7 +64,17 @@ input_dict = {
 			},
 			"optional": True,
 			"description": "Value for variable operating cost. `sum_all_tables()` is used for summing all tables in this group."
-		}
+		},
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed total',
+                'middle_key_total_group_insertion': 'Summed group total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },			
 	}
 }
 
@@ -101,7 +111,16 @@ output_dict = {
     "special_insertions":
         {"sum_all_tables": {
             "<...> Other Variable Operating Cost <...>": {
-                "Summed Total": {
+                "Summed total": {
+                    "Value": {
+                        "type": {float},
+                    },
+                    "optional": False,
+                    "description": "Summed total of other variable in each table"
+                },
+            },
+            "Other Variable Operating Cost": {
+                "Summed group total": {
                     "Value": {
                         "type": {float},
                     },
@@ -109,6 +128,7 @@ output_dict = {
                     "description": "Summed total of other variable operating costs across all tables"
                 },
             },
+
 		},
 	}
 }
@@ -138,9 +158,12 @@ class Variable_Operating_Cost_Plugin:
 
 	Returns
 	-------
-	[...] Other Variable Operating Cost [...] > Summed Total > Value : float
+	[...] Other Variable Operating Cost [...] > Summed total > Value : float
 		Summed total for each individual table in "Other Variable Operating Cost"
 		group.
+	Other Variable Operating Cost > Summed group total > Value : float
+		Summed total for all the tables in "Other Variable Operating Cost"
+		group.		
 	Variable Operating Costs > Total > Value : ndarray
 		Sum of inflation corrected utilities costs and other variable operating costs.
 	Variable Operating Costs > Utilities > Value : ndarray
@@ -154,7 +177,7 @@ class Variable_Operating_Cost_Plugin:
 		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Variable_Operating_Cost_Plugin')
 
 		self.calculate_utilities_cost(dcf)
-		self.other_variable_costs(dcf, print_info)
+		self.other_variable_costs(dcf)
 		self.total_variable_costs = Quantity(self.utilities.unit['USD'] + self.other.unit['USD'], 'USD')	
 
 		output_inserter_function(output_dict, self, dcf, 'Variable_Operating_Cost_Plugin')   
@@ -173,13 +196,11 @@ class Variable_Operating_Cost_Plugin:
 		self.utilities = self.utilities * self.input_dict_resolved['Technical Operating Parameters and Specifications']['Output per year']['Value'].unit['kg']
 		self.utilities = Quantity(self.utilities, 'USD')
 
-	def other_variable_costs(self, dcf, print_info):
+	def other_variable_costs(self, dcf):
 		'''Applying ``sum_all_tables()`` to "Other Variable Operating Cost" group.
 		'''
-
-		self.other = dcf.chemical_inflator * sum_all_tables(self.input_dict_resolved, 'Other Variable Operating Cost', 'Value', 
-																insert_total = True, class_object = dcf, 
-																print_info = print_info).unit['USD'] 
+		self.Other_variable_operating_cost_total = self.input_dict_resolved['Other Variable Operating Cost']['Summed group total']['Value'] # Calculated by sum_tables
+		self.other = dcf.chemical_inflator * self.Other_variable_operating_cost_total.unit['USD'] 
 		self.other = Quantity(self.other, 'USD')
 
 class Utility:

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -60,6 +60,52 @@ input_dict = {
 	}
 }
 
+
+output_dict = {
+    "Variable Operating Costs": {
+		"Total": {
+			"Value": {
+				"inserted_value": "utilities + other",
+				"type": {float, np.ndarray},
+				"dimension": "currency / time",
+			},
+			"optional": False,
+			"description": "Total variable operating costs, including utilities and other variable operating costs."
+		},
+		"Utilities": {
+			"Value": {
+				"inserted_value": "utilities",
+				"type": {float, np.ndarray},
+				"dimension": "currency / time",
+			},
+			"optional": False,
+			"description": "Total variable operating costs for utilities, including inflation correction."
+		},
+		"Other": {
+			"Value": {
+				"inserted_value": "other",
+				"type": {float},
+				"dimension": "currency / time",
+			},
+			"optional": False,
+			"description": "Total variable operating costs for other variable operating costs."
+		},
+	},
+    "special_insertions":
+        {"sum_all_tables": {
+            "<...> Other Variable Operating Cost <...>": {
+                "Summed Total": {
+                    "Value": {
+                        "type": {int, float},
+                    },
+                    "optional": True,
+                    "description": "Summed total of other variable operating costs across all tables"
+                },
+            },
+		},
+	}
+}
+
 class Variable_Operating_Cost_Plugin:
 	'''Calculation of variable operating costs.
 

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -41,12 +41,16 @@ input_dict = {
 			"Price_Conversion_Factor_Unit": {
 				"dimension": "dimensionless"
 			},
+			"Cost_Path": {
+				"type": {str},
+				"bounds": None, 
+			},			
 			"Usage_Path": {
 				"type": {str},
 				"bounds": None, 
 			},
 			"optional": True,
-			"description": "Utilities are specified by specifying the cost of a given utility (e.g. $/kWh(electricity) and specifying the usage of the utility per mass of product (e.g. kWh(electricity)/kg(H2). The cost of the utility may be either a float, a ndarray with the same length as `dcf.inflation_correction` or a textfile containing cost values (cost values have to be in second column). For cost the path key is Path and for usage the path key is Usage Path"
+			"description": "Utilities are specified by specifying the cost of a given utility (e.g. USD of each kWh of electricity and specifying the usage of the utility per mass of product (e.g. kWh of electricity consumption /kg (H2). The cost of the utility may be either a float, a ndarray with the same length as `dcf.inflation_correction` or a textfile containing cost values (cost values have to be in second column). For cost the path key is Cost_Path and for usage the path key is Usage_Path"
 		}
 	},
 	"<...> Other Variable Operating Cost <...>": {
@@ -125,8 +129,10 @@ class Variable_Operating_Cost_Plugin:
 	Utilities > [...] > Price_Conversion_Factor : float
 		Conversion factor between cost and usage units. Should be set to 1 if no conversion is
 		required.
-	Utilities > [...] > Usage_Path : str, optional
-		Path for `Usage per kg H2` entry.
+	Utilities > [...] > Cost_Path : str
+		Path for `Cost` entry. If no such path is needed, the Cost_Path column must exist and be left empty.
+	Utilities > [...] > Usage_Path : str
+		Path for `Usage` entry. If no such path is needed, the Usage_Path column must exist and be left empty.
 	[...] Other Variable Operating Operating Cost [...] >> Value : float
 		``sum_all_tables()`` is used.
 
@@ -144,6 +150,7 @@ class Variable_Operating_Cost_Plugin:
 	'''
 
 	def __init__(self, dcf, print_info):
+
 		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Variable_Operating_Cost_Plugin')
 
 		self.calculate_utilities_cost(dcf)

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -196,7 +196,7 @@ class Utility:
 			years_idx = fn.find_nearest(prices, dcf.years)
 			prices = prices[years_idx]
 
-			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price_Conversion_Factor_Value'].unit['-'] * dictionary['Usage_Value'], 'USD/kg') 
+			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price_Conversion_Factor_Value'].unit['-'] * dictionary['Usage_Value'].unit['-/kg'], 'USD/kg') 
 
 		else:
 			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost_Value'].unit['USD'] * dictionary['Usage_Value'].unit['-/kg'] * dictionary['Price_Conversion_Factor_Value'].unit['-']

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -172,7 +172,7 @@ class Variable_Operating_Cost_Plugin:
 
 		self.other = dcf.chemical_inflator * sum_all_tables(self.input_dict_resolved, 'Other Variable Operating Cost', 'Value', 
 																insert_total = True, class_object = dcf, 
-																print_info = print_info, unit = 'USD') # Unit will need to be removed after we correct sum_all_tables
+																print_info = print_info) # Unit will need to be removed after we correct sum_all_tables
 		self.other = Quantity(self.other, 'USD')
 
 class Utility:

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -196,7 +196,7 @@ class Utility:
 			years_idx = fn.find_nearest(prices, dcf.years)
 			prices = prices[years_idx]
 
-			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price Conversion Factor'].unit['-'] * dictionary['Usage'], 'USD/kg') # probleme in this plugin: we don't know the units in advance
+			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price_Conversion_Factor_Value'].unit['-'] * dictionary['Usage_Value'], 'USD/kg') 
 
 		else:
 			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost_Value'].unit['USD'] * dictionary['Usage_Value'].unit['-/kg'] * dictionary['Price_Conversion_Factor_Value'].unit['-']

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -172,7 +172,7 @@ class Variable_Operating_Cost_Plugin:
 
 		self.other = dcf.chemical_inflator * sum_all_tables(self.input_dict_resolved, 'Other Variable Operating Cost', 'Value', 
 																insert_total = True, class_object = dcf, 
-																print_info = print_info) # Unit will need to be removed after we correct sum_all_tables
+																print_info = print_info).unit['USD'] 
 		self.other = Quantity(self.other, 'USD')
 
 class Utility:

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -1,4 +1,4 @@
-from pyH2A.Utilities.input_modification import sum_all_tables, read_textfile
+from pyH2A.Utilities.input_modification import read_textfile
 from pyH2A.Utilities.IO import input_resolver_function, output_inserter_function
 from pyH2A.Utilities.Unit_Handler.quantity import Quantity
 import pyH2A.Utilities.find_nearest as fn
@@ -15,13 +15,13 @@ input_dict = {
 				"dimension": "mass"
 			},
 			"optional": False,
-			"description": "Yearly output taking operating capacity factor into account, in mass of H2"
+			"description": "Yearly output taking operating capacity factor into account"
 		}
 	},
 	"Utilities": {
 		"<...>": {
 			"Cost_Value": {
-				"type": {float, str, np.ndarray},
+				"type": {int, float, str, np.ndarray},
 				"bounds": (0, None),
 				"path": "Cost_Path"
 			},
@@ -29,28 +29,36 @@ input_dict = {
 				"dimension": "currency" # we omit the basis on purpose, at it is transparent, and will simplify with the basis per kg; the raito is precisely what the conversion factor is there for
 			},			
 			"Usage_Value": {
-				"type": {float},
+				"type": {int, float},
 				"bounds": (0, None), 
 				"path": "Usage_Path"
 			},
 			"Usage_Unit": {
-				"dimension": "1/mass" # basis per kg of hydrogen
+				"dimension": "1/mass" # basis per kg of product
 			},			
 			"Price_Conversion_Factor_Value": {
-				"type": {float},
+				"type": {int, float},
 				"bounds": (0, None)
 			},
 			"Price_Conversion_Factor_Unit": {
 				"dimension": "dimensionless"
 			},		
 			"optional": True,
-			"description": "Utilities are specified by specifying the cost of a given utility (e.g. USD of each kWh of electricity) and specifying the usage of the utility per mass of product (e.g. kWh of electricity consumption /kg (H2). The cost of the utility may be either a float, a ndarray with the same length as `dcf.inflation_correction` or a textfile containing cost values (cost values have to be in second column). For cost the path key is Cost_Path and for usage the path key is Usage_Path"
+			"description": "Utilities are specified by specifying the cost of "
+						   "a given utility (e.g. USD of each kWh of electricity) and"
+						   " specifying the usage of the utility per mass of product"
+						   " (e.g. kWh of electricity consumption /kg (H2). "
+						   "The cost of the utility may be either a float, "
+						   "a ndarray with the same length as `dcf.inflation_correction` "
+						   "or a textfile containing cost values "
+						   "(cost values have to be in second column). "
+						   "For cost the path key is Cost_Path and for usage the path key is Usage_Path"
 		}
 	},
 	"<...> Other Variable Operating Cost <...>": {
 		"<...>": {
 			"Value": {
-				"type": {float, np.ndarray},
+				"type": {int, float,},
 				"bounds": (0, None)
 			},
 			"Unit": {
@@ -77,7 +85,7 @@ output_dict = {
 		"Total": {
 			"Value": {
 				"inserted_value": "total_variable_costs",
-				"type": {float, np.ndarray},
+				"type": {np.ndarray},
 				"dimension": "currency",
 			},
 			"optional": False,
@@ -86,7 +94,7 @@ output_dict = {
 		"Utilities": {
 			"Value": {
 				"inserted_value": "utilities",
-				"type": {float, np.ndarray},
+				"type": {np.ndarray},
 				"dimension": "currency",
 			},
 			"optional": False,
@@ -95,7 +103,7 @@ output_dict = {
 		"Other": {
 			"Value": {
 				"inserted_value": "other",
-				"type": {float, np.ndarray},
+				"type": {int, float},
 				"dimension": "currency",
 			},
 			"optional": False,
@@ -107,13 +115,20 @@ output_dict = {
             "<...> Other Variable Operating Cost <...>": {
                 "Summed total": {
                     "Value": {
-                        "type": {float},
+                        "type": {int, float},
                     },
                     "optional": False,
-                    "description": "Summed total of other variable in each table"
+                    "description": "Summed total of other variable operating costs in each table"
                 },
             },
             "Other Variable Operating Cost": {
+				"Summed total": {
+					"Value": {
+						'type': {int, float},
+					},
+					"optional": False,
+					"description": "Summed total of other variable operating costs in this table."
+				},
                 "Summed group total": {
                     "Value": {
                         "type": {float},
@@ -171,9 +186,10 @@ class Variable_Operating_Cost_Plugin:
 
 		self.calculate_utilities_cost(dcf)
 		self.other_variable_costs(dcf)
-		self.total_variable_costs = Quantity(self.utilities.unit['USD'] + self.other.unit['USD'], 'USD')	
-		output_inserter_function(output_dict, self, dcf, 'Variable_Operating_Cost_Plugin')   
 
+		self.total_variable_costs = Quantity(self.utilities.unit['USD'] + self.other.unit['USD'], 'USD')	
+
+		output_inserter_function(output_dict, self, dcf, 'Variable_Operating_Cost_Plugin')   
 
 	def calculate_utilities_cost(self, dcf):
 		'''Iterating over all utilities and computing summed yearly costs.
@@ -183,32 +199,35 @@ class Variable_Operating_Cost_Plugin:
 
 		for key in self.input_dict_resolved['Utilities']:
 			utility = Utility(self.input_dict_resolved['Utilities'][key], dcf)
-			self.utilities += utility.cost_per_kg_H2.unit['USD/kg']
+			self.utilities += utility.cost_per_unit_of_product.unit['USD/kg']
 
-		self.utilities = self.utilities * self.input_dict_resolved['Technical Operating Parameters and Specifications']['Output per year']['Value'].unit['kg']
+		self.utilities = (self.utilities 
+						  * self.input_dict_resolved['Technical Operating Parameters and Specifications']['Output per year']['Value'].unit['kg'])
 		self.utilities = Quantity(self.utilities, 'USD')
 
 	def other_variable_costs(self, dcf):
-		'''Applying ``sum_all_tables()`` to "Other Variable Operating Cost" group.
 		'''
-		self.Other_variable_operating_cost_total = self.input_dict_resolved['Other Variable Operating Cost']['Summed group total']['Value'] # Calculated by sum_tables
-		self.other = dcf.chemical_inflator * self.Other_variable_operating_cost_total.unit['USD'] 
-		self.other = Quantity(self.other, 'USD')
+		Applying inflation correct to summed other variable operating costs
+		'''
+		self.other = Quantity(
+						dcf.chemical_inflator 
+						* self.input_dict_resolved['Other Variable Operating Cost']['Summed group total']['Value'].unit['USD'], 
+					 'USD') 
 
 class Utility:
 	'''Individual utility objects.
 
 	Methods 
 	-------
-	calculate_cost_per_kg_H2:
+	calculate_cost_per_unit_of_product:
 		Calculation of utility cost per kg of H2 with inflation correction.
 	'''
 
 	def __init__(self, dictionary, dcf):
-		self.calculate_cost_per_kg_H2(dictionary, dcf)
+		self.calculate_cost_per_unit_of_product(dictionary, dcf)
 
-	def calculate_cost_per_kg_H2(self, dictionary, dcf):
-		'''Calculation of utility cost per kg of H2 with inflation correction.
+	def calculate_cost_per_unit_of_product(self, dictionary, dcf):
+		'''Calculation of utility cost per unit of product with inflation correction.
 		'''
 		
 		if isinstance(dictionary['Cost_Value'], str):
@@ -216,8 +235,22 @@ class Utility:
 			years_idx = fn.find_nearest(prices, dcf.years)
 			prices = prices[years_idx]
 
-			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price_Conversion_Factor_Value'].unit['-'] * dictionary['Usage_Value'].unit['1/kg'], 'USD/kg') 
+			self.cost_per_unit_of_product = Quantity(prices[:,1] 
+													 * dcf.inflation_correction 
+													 * dictionary['Price_Conversion_Factor_Value'].unit['-'] 
+													 * dictionary['Usage_Value'].unit['1/kg'], 
+											 'USD/kg') 
+
+		elif isinstance(dictionary['Cost_Value'], (int, float, np.ndarray)):
+
+			annual_cost_per_unit_of_product = (dictionary['Cost_Value'].unit['USD'] 
+											   * dcf.inflation_correction 
+											   * dictionary['Price_Conversion_Factor_Value'].unit['-']
+											   * dictionary['Usage_Value'].unit['1/kg'])
+			
+			self.cost_per_unit_of_product = Quantity(np.ones(len(dcf.inflation_factor)) 
+													 * annual_cost_per_unit_of_product, 
+											'USD/kg')
 
 		else:
-			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost_Value'].unit['USD'] * dictionary['Usage_Value'].unit['1/kg'] * dictionary['Price_Conversion_Factor_Value'].unit['-']
-			self.cost_per_kg_H2 = Quantity(np.ones(len(dcf.inflation_factor)) * annual_cost_per_kg_H2, 'USD/kg')
+			raise ValueError(f"Unsupported type for Cost_Value ({dictionary['Cost_Value']}): {type(dictionary['Cost_Value'])}. Must be either str, int, float or np.ndarray.")

--- a/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Variable_Operating_Cost_Plugin.py
@@ -34,7 +34,7 @@ input_dict = {
 				"path": "Usage_Path"
 			},
 			"Usage_Unit": {
-				"dimension": "dimensionless/mass" # basis per kg of hydrogen
+				"dimension": "1/mass" # basis per kg of hydrogen
 			},			
 			"Price_Conversion_Factor_Value": {
 				"type": {float},
@@ -216,8 +216,8 @@ class Utility:
 			years_idx = fn.find_nearest(prices, dcf.years)
 			prices = prices[years_idx]
 
-			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price_Conversion_Factor_Value'].unit['-'] * dictionary['Usage_Value'].unit['-/kg'], 'USD/kg') 
+			self.cost_per_kg_H2 = Quantity(prices[:,1] * dcf.inflation_correction * dictionary['Price_Conversion_Factor_Value'].unit['-'] * dictionary['Usage_Value'].unit['1/kg'], 'USD/kg') 
 
 		else:
-			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost_Value'].unit['USD'] * dictionary['Usage_Value'].unit['-/kg'] * dictionary['Price_Conversion_Factor_Value'].unit['-']
+			annual_cost_per_kg_H2 = dcf.inflation_correction * dictionary['Cost_Value'].unit['USD'] * dictionary['Usage_Value'].unit['1/kg'] * dictionary['Price_Conversion_Factor_Value'].unit['-']
 			self.cost_per_kg_H2 = Quantity(np.ones(len(dcf.inflation_factor)) * annual_cost_per_kg_H2, 'USD/kg')

--- a/src/tests/plugins/variable_operating_cost_plugin_test.py
+++ b/src/tests/plugins/variable_operating_cost_plugin_test.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from pyH2A.Plugins.Variable_Operating_Cost_Plugin import Variable_Operating_Cost_Plugin
+from pyH2A.Utilities.Unit_Handler.quantity import Quantity
 
 
 class DummyDCF:
@@ -16,17 +17,22 @@ class DummyDCF:
     ):  
         self.inp = {
             "Technical Operating Parameters and Specifications": {
-                "Output per Year": {"Value": plant_output_per_year}
+                "Output per year": {"Value": plant_output_per_year, "Unit":"kg/year"}
             },
             "Utilities": {
                 key: {
-                    "Cost": value["Cost"],
-                    "Usage per kg H2": value["Usage"],
-                    "Price Conversion Factor": value.get("Conversion", 1.0)
-                } for key, value in utilities.items()
+                    "Cost_Value": value["Cost"], "Cost_Unit":"USD",
+                    "Usage_Value": value["Usage"], "Usage_Unit":"-/kg", "Usage_Path": "",
+                    "Price_Conversion_Factor_Value": value.get("Conversion", 1.0), "Price_Conversion_Factor_Unit": "-",
+                } 
+                for key, value in utilities.items()
             },
             "Dummy Left Other Variable Operating Cost Dummy Right": {
-                key: {"Value": value} for key, value in other_variable_costs.items()
+                key: {
+                    "Value": value["Cost_Value"],
+                    "Unit": "USD"
+                }
+                for key, value in other_variable_costs.items()
             }
         }
         
@@ -47,16 +53,22 @@ class DummyDCF:
                     "Water": {"Cost": 0.01, "Usage": 10.0}          
                 },
                 "other_variable_costs": {
-                    "Maintenance": 1000.0,
-                    "Chemicals": 500.0
+                    "Maintenance": {
+                        "Cost_Value": 1000.0,
+                        "Cost_Unit": "USD"
+                    },
+                    "Chemicals": {
+                        "Cost_Value": 500.0,
+                        "Cost_Unit": "USD"
+                    }
                 },
                 "inflation_correction": 1.2,
                 "chemical_inflator": 1.0
             },
             "expected": {
-                "utilities": np.array([612000.0, 612000.0, 612000.0, 612000.0, 612000.0, 612000.0, 612000.0,
-              612000.0, 612000.0, 612000.0]), 
-                "other": np.array(1500.),                                      
+                "utilities": Quantity(np.array([612000.0, 612000.0, 612000.0, 612000.0, 612000.0, 612000.0, 612000.0,
+              612000.0, 612000.0, 612000.0]), "USD"),
+                "other": Quantity(np.array(1500.), "USD")                                      
             }
         }
     ]
@@ -75,13 +87,13 @@ def test_variable_operating_cost_plugin(case):
     tolerance = 1e-12
 
     np.testing.assert_allclose(
-        plugin.utilities, 
-        expected["utilities"], 
+        plugin.utilities.unit["USD"], 
+        expected["utilities"].unit["USD"], 
         rtol=tolerance
     )
     
     np.testing.assert_allclose(
-        plugin.other, 
-        expected["other"], 
+        plugin.other.unit["USD"], 
+        expected["other"].unit["USD"], 
         rtol=tolerance
     )

--- a/src/tests/plugins/variable_operating_cost_plugin_test.py
+++ b/src/tests/plugins/variable_operating_cost_plugin_test.py
@@ -17,7 +17,7 @@ class DummyDCF:
     ):  
         self.inp = {
             "Technical Operating Parameters and Specifications": {
-                "Output per year": {"Value": plant_output_per_year, "Unit":"kg/year"}
+                "Output per year": {"Value": plant_output_per_year, "Unit":"kg"}
             },
             "Utilities": {
                 key: {

--- a/src/tests/plugins/variable_operating_cost_plugin_test.py
+++ b/src/tests/plugins/variable_operating_cost_plugin_test.py
@@ -17,13 +17,21 @@ class DummyDCF:
     ):  
         self.inp = {
             "Technical Operating Parameters and Specifications": {
-                "Output per year": {"Value": plant_output_per_year, "Unit":"kg"}
+                "Output per year": {
+                    "Value": plant_output_per_year, 
+                    "Unit":"kg"
+                    }
             },
             "Utilities": {
                 key: {
-                    "Cost_Value": value["Cost"], "Cost_Unit":"USD", "Cost_Path": "",
-                    "Usage_Value": value["Usage"], "Usage_Unit":"1/kg", "Usage_Path": "",
-                    "Price_Conversion_Factor_Value": value.get("Conversion", 1.0), "Price_Conversion_Factor_Unit": "-",
+                    "Cost_Value": value["Cost"], 
+                    "Cost_Unit": "USD", 
+                    "Cost_Path": "None",
+                    "Usage_Value": value["Usage"], 
+                    "Usage_Unit": "1/kg", 
+                    "Usage_Path": "None",
+                    "Price_Conversion_Factor_Value": value.get("Conversion", 1.0),
+                    "Price_Conversion_Factor_Unit": "-",
                 } 
                 for key, value in utilities.items()
             },
@@ -49,8 +57,13 @@ class DummyDCF:
             "input": {
                 "plant_output_per_year": 100_000.0,  
                 "utilities": {
-                    "Electricity": {"Cost": 0.05, "Usage": 50.0, "Conversion": 2.0}, 
-                    "Water": {"Cost": 0.01, "Usage": 10.0}          
+                    "Electricity": {
+                        "Cost": 0.05, 
+                        "Usage": 50.0, 
+                        "Conversion": 2.0}, 
+                    "Water": {
+                        "Cost": 0.01, 
+                        "Usage": 10.0}          
                 },
                 "other_variable_costs": {
                     "Maintenance": {
@@ -66,8 +79,17 @@ class DummyDCF:
                 "chemical_inflator": 1.0
             },
             "expected": {
-                "utilities": Quantity(np.array([612000.0, 612000.0, 612000.0, 612000.0, 612000.0, 612000.0, 612000.0,
-              612000.0, 612000.0, 612000.0]), "USD"),
+                "utilities": Quantity(np.array([612000.0, 
+                                                612000.0, 
+                                                612000.0, 
+                                                612000.0, 
+                                                612000.0, 
+                                                612000.0, 
+                                                612000.0,
+                                                612000.0, 
+                                                612000.0, 
+                                                612000.0]), 
+                                        "USD"),
                 "other": Quantity(np.array(1500.), "USD")                                      
             }
         }

--- a/src/tests/plugins/variable_operating_cost_plugin_test.py
+++ b/src/tests/plugins/variable_operating_cost_plugin_test.py
@@ -21,7 +21,7 @@ class DummyDCF:
             },
             "Utilities": {
                 key: {
-                    "Cost_Value": value["Cost"], "Cost_Unit":"USD",
+                    "Cost_Value": value["Cost"], "Cost_Unit":"USD", "Cost_Path": "",
                     "Usage_Value": value["Usage"], "Usage_Unit":"-/kg", "Usage_Path": "",
                     "Price_Conversion_Factor_Value": value.get("Conversion", 1.0), "Price_Conversion_Factor_Unit": "-",
                 } 

--- a/src/tests/plugins/variable_operating_cost_plugin_test.py
+++ b/src/tests/plugins/variable_operating_cost_plugin_test.py
@@ -22,7 +22,7 @@ class DummyDCF:
             "Utilities": {
                 key: {
                     "Cost_Value": value["Cost"], "Cost_Unit":"USD", "Cost_Path": "",
-                    "Usage_Value": value["Usage"], "Usage_Unit":"-/kg", "Usage_Path": "",
+                    "Usage_Value": value["Usage"], "Usage_Unit":"1/kg", "Usage_Path": "",
                     "Price_Conversion_Factor_Value": value.get("Conversion", 1.0), "Price_Conversion_Factor_Unit": "-",
                 } 
                 for key, value in utilities.items()


### PR DESCRIPTION
# Refactor variable operating cost plugin

# IMPORTANT NOTES
- currently the sum_all_tables method is not compatible with the Quantities in this branch, so the test fails. This is expected and will work again after we merge #60 into Master, then back into this PR.
- Depends on #68 : I was forced to add to the test an empty "Usage_Path", because the code expects this key to be there. The thing is that in the input_dict, we can't say that the path itself is optional, we can apply the "optional"  option to a mid key altogether, not to the path. 


# Description

- Insert output_dict
- Adapt the code to use IO resolver
- update plugin test
- update docstrings


# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [x] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [x] Design / Architecture change


# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [ ] Unit tests
- [ ] Integration tests
- [ ] Performance tests
- [x] Manual tests / example model runs

## Test Details:
plugin test runs fine locally

# Checklist
- [x] Code follows pyH2A style guidelines
- [x] Self-review of code completed
- [x] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [x] No new warnings generated
- [x] Tests added / updated and passing
- [ ] Dependent changes merged and published
