### PR TITLE
Refactor: Update the plugin and test - Hourly Irradiation Plugin

### DIFF
--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -150,7 +150,7 @@ class Hourly_Irradiation_Plugin:
 	----------
 	Hourly Irradiation > File > Value : str
 		Path to a `.csv` file containing hourly irradiance data as provided by
-		https://re.jrc.ec.europa.eu/pvg_tools/en/#TMY, ``process_table()`` is used.
+		https://re.jrc.ec.europa.eu/pvg_tools/en/#TMY.
 	Irradiance Area Parameters > Module tilt > Value : float, optional
 		Tilt angle of irradiated module. Defaults to the absolute value of the latitude.
 	Irradiance Area Parameters > Array azimuth > Value : float
@@ -298,9 +298,9 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 	total_plane_radiation = direct_plane_radiation + diffuse_plane_radiation
 
 	cell_temperature = data['Temperature'].unit['degC'] + (nominal_operating_temperature.unit['degC'] - 
-					   20) * total_plane_radiation/800  #where does this formula come from?
+					   20) * total_plane_radiation/800  
 
-	temperature_derating = 1 + temperature_coefficient.unit['-/delta_degC'] * (cell_temperature - 25)  # why the 25 correction?
+	temperature_derating = 1 + temperature_coefficient.unit['-/delta_degC'] * (cell_temperature - 25)  
 
 	power = Quantity((temperature_derating * mismatch_derating.unit['-'] * 
 					 dirt_derating.unit['-'] * total_plane_radiation), 'W/m2')

--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -23,7 +23,7 @@ input_dict = {
 			"Unit": {
 				"dimension": "angle",
 			},
-			"optional": False,
+			"optional": True, # we always need a tilt, but it's optional as an explicit input because it defaults to the latitude
 			"description": "Tilt of irradiated module."
 		},
 		"Array azimuth": {
@@ -43,7 +43,7 @@ input_dict = {
 				"bounds": (250, 500),
 			},
 			"Unit": {
-				"dimension": "temperature",
+				"dimension": "absolute_temperature",
 			},
 			"optional": False,
 			"description": "Nominal operating temperature of irradiated module."
@@ -76,7 +76,7 @@ input_dict = {
 				"bounds": (-0.1, 0), 
 			},
 			"Unit": {
-				"dimension": "dimensionless/temperature",
+				"dimension": "dimensionless/temperature_diff",
 			},
 			"optional": False,
 			"description": "Performance decrease of irradiated module per degree increase."
@@ -88,7 +88,7 @@ output_dict = {
 	"Hourly Irradiation": {
 		"No tracking": {
 			"Value": {
-				"insert_value": "power",
+				"inserted_value": "power",
 				"type": {np.ndarray,},
 				"dimension": "power / area",
 			},
@@ -97,7 +97,7 @@ output_dict = {
 		},
 		"Horizontal single axis tracking": {
 			"Value": {
-				"insert_value": "power_sat",
+				"inserted_value": "power_sat",
 				"type": {np.ndarray,},
 				"dimension": "power / area",
 			},
@@ -106,7 +106,7 @@ output_dict = {
 		},
 		"Two axis tracking": {
 			"Value": {
-				"insert_value": "power_dat",
+				"inserted_value": "power_dat",
 				"type": {np.ndarray,},
 				"dimension": "power / area",
 			},
@@ -115,7 +115,7 @@ output_dict = {
 		},
 		"Mean solar input no tracking": {
 			"Value": {
-				"insert_value": "self.yearly_averaged_power",
+				"inserted_value": "yearly_averaged_power",
 				"type": {float,},
 				"dimension": "power / area",
 			},
@@ -124,7 +124,7 @@ output_dict = {
 		},
 		"Mean solar input single axis tracking": {
 			"Value": {
-				"insert_value": "self.yearly_averaged_power_sat",
+				"inserted_value": "yearly_averaged_power_sat",
 				"type": {float,},
 				"dimension": "power / area",
 			},
@@ -133,7 +133,7 @@ output_dict = {
 		},
 		"Mean solar input two axis tracking": {
 			"Value": {
-				"insert_value": "self.yearly_averaged_power_dat",
+				"inserted_value": "yearly_averaged_power_dat",
 				"type": {float,},
 				"dimension": "power / area",
 			},
@@ -151,33 +151,33 @@ class Hourly_Irradiation_Plugin:
 	Hourly Irradiation > File > Value : str
 		Path to a `.csv` file containing hourly irradiance data as provided by
 		https://re.jrc.ec.europa.eu/pvg_tools/en/#TMY, ``process_table()`` is used.
-	Irradiance Area Parameters > Module Tilt (degrees) > Value : float
-		Tilt of irradiated module in degrees.
-	Irradiance Area Parameters > Array Azimuth (degrees) > Value : float
-		Azimuth angle of irradiated module in degrees.
-	Irradiance Area Parameters > Nominal Operating Temperature (Celsius) > Value : float
-		Nominal operating temperature of irradiated module in degrees Celsius.
-	Irradiance Area Parameters > Mismatch Derating > Value : float
-		Derating value due to mismatch (percentage or value between 0 and 1).
-	Irradiance Area Parameters > Dirt Derating > Value : float
-		Derating value due to dirt buildup (percentage or value between 0 and 1).
-	Irradiance Area Parameters > Temperature Coefficient (per Celsius) > Value : float
-		Performance decrease of irradiated module per degree Celsius increase.
+	Irradiance Area Parameters > Module tilt > Value : float, optional
+		Tilt angle of irradiated module. Defaults to the absolute value of the latitude.
+	Irradiance Area Parameters > Array azimuth > Value : float
+		Azimuth angle of irradiated module.
+	Irradiance Area Parameters > Nominal operating temperature > Value : float
+		Nominal operating temperature of irradiated module.
+	Irradiance Area Parameters > Mismatch derating > Value : float
+		Derating value due to mismatch (dimensionless value between 0 and 1).
+	Irradiance Area Parameters > Dirt derating > Value : float
+		Derating value due to dirt buildup (dimensionless value between 0 and 1).
+	Irradiance Area Parameters > Temperature coefficient > Value : float
+		Performance decrease of irradiated module per temperature unit increase.
 
 	Returns
 	-------
-	Hourly Irradiation > No Tracking (kW) > Value : ndarray
-		Hourly irradiation with no tracking per m2 in kW.
-	Hourly Irradiation > Horizontal Single Axis Tracking (kW) > Value : ndarray
-		Hourly irradiation with single axis tracking per m2 in kW.
-	Hourly Irradiation > Two Axis Tracking (kW) > Value : ndarray
-		Hourly irradiation with two axis tracking per m2 in kW.
-	Hourly Irradiation > Mean solar input (kWh/m2/day) > Value : float
-		Mean solar input with no tracking in kWh/m2/day.
-	Hourly Irradiation > Mean solar input, single axis tracking (kWh/m2/day) > Value : float
-		Mean solar input with single axis tracking in kWh/m2/day.
-	Hourly Irradiation > Mean solar input, two axis tracking (kWh/m2/day) > Value : float
-		Mean solar input with two axis tracking in kWh/m2/day.
+	Hourly Irradiation > No tracking > Value : ndarray
+		Hourly irradiation poer with no tracking per area.
+	Hourly Irradiation > Horizontal single axis tracking > Value : ndarray
+		Hourly irradiation power with single axis tracking per area.
+	Hourly Irradiation > Two axis tracking > Value : ndarray
+		Hourly irradiation power with two axis tracking per area.
+	Hourly Irradiation > Mean solar input > Value : float
+		Mean solar input power with no tracking in per area.
+	Hourly Irradiation > Mean solar input, single axis tracking > Value : float
+		Mean solar input power with single axis tracking per area.
+	Hourly Irradiation > Mean solar input, two axis tracking > Value : float
+		Mean solar input power with two axis tracking per area.
 	'''
 
 	def __init__(self, dcf, print_info):
@@ -185,8 +185,8 @@ class Hourly_Irradiation_Plugin:
 		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Hourly_Irradiation_Plugin')
 
 		pv = self.input_dict_resolved['Irradiance Area Parameters']
-		if 'Module Tilt (degrees)' in pv:
-			tilt = pv['Module Tilt (degrees)']['Value']
+		if 'Module tilt' in pv:
+			tilt = pv['Module tilt']['Value']
 		else: # if we want to make the tilt equal to latitude, we don't point it through a path in the input fiale, we let it be the default
 			tilt = 'Default' 
 
@@ -267,10 +267,10 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 	latitude = Quantity(location['Latitude (decimal degrees)'], 'deg')
 	longitude = Quantity(location['Longitude (decimal degrees)'], 'deg')
 
-	if module_tilt is 'Default':
+	if module_tilt == 'Default':
 		module_tilt = Quantity(np.abs(location['Latitude (decimal degrees)']), 'deg')
 
-	day_number = np.arange(1, len(data['Time']) + 1) / 24
+	day_number = np.arange(1, len(data['Time'].unit['-']) + 1) / 24
 	#day_number = np.arange(0, len(data['Time'])) / 24
 
 	declination_angle = Quantity(23.45 * np.sin((day_number - 81) * 2 * np.pi / 365.),'deg')
@@ -278,14 +278,14 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 
 	altitude_angle = Quantity(
 					np.arcsin(np.sin(declination_angle.unit['rad']) * 
-					np.sin(latitude.unit('rad')) + np.cos(declination_angle.unit['rad']) * 
-					np.cos(latitude.unit('rad')) * np.cos(2 * np.pi / 360 * hour_angle)), 
+					np.sin(latitude.unit['rad']) + np.cos(declination_angle.unit['rad']) * 
+					np.cos(latitude.unit['rad']) * np.cos(hour_angle.unit['rad'])), 
 					'rad')
 
 	azimuth_angle = Quantity(
 					np.arccos((np.sin(declination_angle.unit['rad']) * 
-					np.cos(latitude.unit('rad')) - np.cos(declination_angle.unit['rad']) * 
-					np.sin(latitude.unit('rad')) * np.cos(hour_angle.unit['rad'])) / 
+					np.cos(latitude.unit['rad']) - np.cos(declination_angle.unit['rad']) * 
+					np.sin(latitude.unit['rad']) * np.cos(hour_angle.unit['rad'])) / 
 					np.cos(altitude_angle.unit['rad'])) * np.sign(hour_angle.unit['rad']), 
 					'rad')
 
@@ -300,7 +300,7 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 	cell_temperature = data['Temperature'].unit['degC'] + (nominal_operating_temperature.unit['degC'] - 
 					   20) * total_plane_radiation/800  #where does this formula come from?
 
-	temperature_derating = 1 + temperature_coefficient.unit['-/degC'] * (cell_temperature - 25)  # why the 25 correction?
+	temperature_derating = 1 + temperature_coefficient.unit['-/delta_degC'] * (cell_temperature - 25)  # why the 25 correction?
 
 	power = Quantity((temperature_derating * mismatch_derating.unit['-'] * 
 					 dirt_derating.unit['-'] * total_plane_radiation), 'W/m2')

--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -82,6 +82,83 @@ input_dict = {
 	},
 }
 
+output_dict = {
+	"Hourly Irradiation": {
+		"Latitude": {
+			"Value": {
+				"insert_value": "Latitude (decimal degrees)",
+				"type": {float,},
+				"dimension": "angle",
+			},
+			"optional": False,
+			"description": "Latitude of location of hourly irradiation data."
+		},
+		"Longitude": {
+			"Value": {
+				"insert_value": "Longitude (decimal degrees)",
+				"type": {float,},
+				"dimension": "angle",
+			},
+			"optional": False,
+			"description": "Longitude of location of hourly irradiation data."
+		},
+		"No tracking": {
+			"Value": {
+				"insert_value": "power_kW",
+				"type": {np.ndarray,},
+				"dimension": "power / area",
+			},
+			"optional": False,
+			"description": "Hourly irradiation with no tracking per m2."
+		},
+		"Horizontal single axis tracking": {
+			"Value": {
+				"insert_value": "power_sat_kW",
+				"type": {np.ndarray,},
+				"dimension": "power / area",
+			},
+			"optional": False,
+			"description": "Hourly irradiation with single axis tracking per m2."
+		},
+		"Two axis tracking": {
+			"Value": {
+				"insert_value": "power_dat_kW",
+				"type": {np.ndarray,},
+				"dimension": "power / area",
+			},
+			"optional": False,
+			"description": "Hourly irradiation with two axis tracking per m2."
+		},
+		"Mean solar input no tracking": {
+			"Value": {
+				"insert_value": "np.sum(power_kW)/365.",
+				"type": {float,},
+				"dimension": "energy / area / time",
+			},
+			"optional": False,
+			"description": "Mean solar input with no tracking."
+		},
+		"Mean solar input single axis tracking": {
+			"Value": {
+				"insert_value": "np.sum(power_sat_kW)/365.",
+				"type": {float,},
+				"dimension": "energy / area / time",
+			},
+			"optional": False,
+			"description": "Mean solar input with single axis tracking."
+		},
+		"Mean solar input two axis tracking": {
+			"Value": {
+				"insert_value": "np.sum(power_dat_kW)/365.",
+				"type": {float,},
+				"dimension": "energy / area / time",
+			},
+			"optional": False,
+			"description": "Mean solar input with two axis tracking."
+		},
+	},
+}
+
 class Hourly_Irradiation_Plugin:
 	'''Calculation of hourly and mean daily irradiation data with different module configurations.
 	

--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -1,6 +1,8 @@
 import numpy as np
 from functools import lru_cache
-from pyH2A.Utilities.input_modification import insert, process_table, read_textfile, file_import
+from pyH2A.Utilities.input_modification import read_textfile, file_import
+from pyH2A.Utilities.IO import input_resolver_function, output_inserter_function
+from pyH2A.Utilities.Unit_Handler.quantity import Quantity
 
 input_dict = {
 	"Hourly Irradiation": {		
@@ -41,7 +43,7 @@ input_dict = {
 				"bounds": (250, 500),
 			},
 			"Unit": {
-				"dimension": "dimensionless / temperature",
+				"dimension": "temperature",
 			},
 			"optional": False,
 			"description": "Nominal operating temperature of irradiated module."
@@ -74,7 +76,7 @@ input_dict = {
 				"bounds": (-0.1, 0), 
 			},
 			"Unit": {
-				"dimension": "temperature",
+				"dimension": "dimensionless/temperature",
 			},
 			"optional": False,
 			"description": "Performance decrease of irradiated module per degree increase."
@@ -84,27 +86,9 @@ input_dict = {
 
 output_dict = {
 	"Hourly Irradiation": {
-		"Latitude": {
-			"Value": {
-				"insert_value": "Latitude (decimal degrees)",
-				"type": {float,},
-				"dimension": "angle",
-			},
-			"optional": False,
-			"description": "Latitude of location of hourly irradiation data."
-		},
-		"Longitude": {
-			"Value": {
-				"insert_value": "Longitude (decimal degrees)",
-				"type": {float,},
-				"dimension": "angle",
-			},
-			"optional": False,
-			"description": "Longitude of location of hourly irradiation data."
-		},
 		"No tracking": {
 			"Value": {
-				"insert_value": "power_kW",
+				"insert_value": "power",
 				"type": {np.ndarray,},
 				"dimension": "power / area",
 			},
@@ -113,7 +97,7 @@ output_dict = {
 		},
 		"Horizontal single axis tracking": {
 			"Value": {
-				"insert_value": "power_sat_kW",
+				"insert_value": "power_sat",
 				"type": {np.ndarray,},
 				"dimension": "power / area",
 			},
@@ -122,7 +106,7 @@ output_dict = {
 		},
 		"Two axis tracking": {
 			"Value": {
-				"insert_value": "power_dat_kW",
+				"insert_value": "power_dat",
 				"type": {np.ndarray,},
 				"dimension": "power / area",
 			},
@@ -131,27 +115,27 @@ output_dict = {
 		},
 		"Mean solar input no tracking": {
 			"Value": {
-				"insert_value": "np.sum(power_kW)/365.",
+				"insert_value": "self.yearly_averaged_power",
 				"type": {float,},
-				"dimension": "energy / area / time",
+				"dimension": "power / area",
 			},
 			"optional": False,
 			"description": "Mean solar input with no tracking."
 		},
 		"Mean solar input single axis tracking": {
 			"Value": {
-				"insert_value": "np.sum(power_sat_kW)/365.",
+				"insert_value": "self.yearly_averaged_power_sat",
 				"type": {float,},
-				"dimension": "energy / area / time",
+				"dimension": "power / area",
 			},
 			"optional": False,
 			"description": "Mean solar input with single axis tracking."
 		},
 		"Mean solar input two axis tracking": {
 			"Value": {
-				"insert_value": "np.sum(power_dat_kW)/365.",
+				"insert_value": "self.yearly_averaged_power_dat",
 				"type": {float,},
-				"dimension": "energy / area / time",
+				"dimension": "power / area",
 			},
 			"optional": False,
 			"description": "Mean solar input with two axis tracking."
@@ -198,38 +182,21 @@ class Hourly_Irradiation_Plugin:
 
 	def __init__(self, dcf, print_info):
 
-		process_table(dcf.inp, 'Hourly Irradiation', 'Value')
+		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Hourly_Irradiation_Plugin')
 
-		data, location = import_hourly_data(dcf.inp['Hourly Irradiation']['File']['Value'])
+		pv = self.input_dict_resolved['Irradiance Area Parameters']
+		if 'Module Tilt (degrees)' in pv:
+			tilt = pv['Module Tilt (degrees)']['Value']
+		else: # if we want to make the tilt equal to latitude, we don't point it through a path in the input fiale, we let it be the default
+			tilt = 'Default' 
 
-		insert(dcf, 'Hourly Irradiation', 'Latitude', 'Value', 
-			   location['Latitude (decimal degrees)'], __name__, print_info = print_info)
-		insert(dcf, 'Hourly Irradiation', 'Longitude', 'Value', 
-			   location['Longitude (decimal degrees)'], __name__, print_info = print_info)
+		self.power, self.power_sat, self.power_dat, self.yearly_averaged_power, self.yearly_averaged_power_sat, self.yearly_averaged_power_dat = calculate_PV_power_ratio(dcf.inp['Hourly Irradiation']['File']['Value'],
+											tilt, pv['Array azimuth']['Value'],
+											pv['Nominal operating temperature']['Value'], 
+											pv['Temperature coefficient']['Value'],
+											pv['Mismatch derating']['Value'], pv['Dirt derating']['Value'])
 
-		process_table(dcf.inp, 'Irradiance Area Parameters', 'Value')
-
-		pv = dcf.inp['Irradiance Area Parameters']
-
-		self.power_kW, self.power_sat_kW, self.power_dat_kW = calculate_PV_power_ratio(dcf.inp['Hourly Irradiation']['File']['Value'],
-											pv['Module Tilt (degrees)']['Value'], pv['Array Azimuth (degrees)']['Value'],
-											pv['Nominal Operating Temperature (Celsius)']['Value'], 
-											pv['Temperature Coefficient (per Celsius)']['Value'],
-											pv['Mismatch Derating']['Value'], pv['Dirt Derating']['Value'])
-
-		insert(dcf, 'Hourly Irradiation', 'No Tracking (kW)', 'Value', 
-			   self.power_kW, __name__, print_info = print_info)
-		insert(dcf, 'Hourly Irradiation', 'Horizontal Single Axis Tracking (kW)', 'Value', 
-			   self.power_sat_kW, __name__, print_info = print_info)
-		insert(dcf, 'Hourly Irradiation', 'Two Axis Tracking (kW)', 'Value', 
-			   self.power_dat_kW, __name__, print_info = print_info)
-
-		insert(dcf, 'Hourly Irradiation', 'Mean solar input no tracking (kWh/m2/day)', 'Value', 
-			   np.sum(self.power_kW)/365., __name__, print_info = print_info)
-		insert(dcf, 'Hourly Irradiation', 'Mean solar input single axis tracking (kWh/m2/day)', 'Value', 
-			   np.sum(self.power_sat_kW)/365., __name__, print_info = print_info)
-		insert(dcf, 'Hourly Irradiation', 'Mean solar input two axis tracking (kWh/m2/day)', 'Value', 
-			   np.sum(self.power_dat_kW)/365., __name__, print_info = print_info)
+		output_inserter_function(output_dict, self, dcf, 'Hourly_Irradiation_Plugin') 
 
 def converter_function(string):
 	'''Converter function for datetime of hourly irradiation data.'''
@@ -246,8 +213,8 @@ def import_Chang_data(file_name):
 
 	data = read_textfile(file_name, delimiter = '	')
 
-	data_dict = {'Time': data[:,0] - 10., 'Temperature': data[:,1],
-				  'Direct Normal Irradiance': data[:,2], 'Diffuse Horizontal Irradiance': data[:,3]}
+	data_dict = {'Time': Quantity(data[:,0] - 10., '-'), 'Temperature': Quantity(data[:,1], 'degC'),
+				  'Direct Normal Irradiance': Quantity(data[:,2], 'W/m2'), 'Diffuse Horizontal Irradiance': Quantity(data[:,3], 'W/m2')}
 
 	location = {'Latitude (decimal degrees)': -19.25, 'Longitude (decimal degrees)': 146.77}
 
@@ -278,8 +245,8 @@ def import_hourly_data(file_name):
 			break
 	file_read.close()
 
-	data_dict = {'Time': data[:,0], 'Temperature': data[:,1], 'Global Horizontal Irradiance':  data[:,3],
-				 'Direct Normal Irradiance': data[:,4], 'Diffuse Horizontal Irradiance': data[:,5]}
+	data_dict = {'Time': Quantity(data[:,0], '-'), 'Temperature': Quantity(data[:,1], 'degC'), 'Global Horizontal Irradiance':  Quantity(data[:,3], 'W/m2'),
+				 'Direct Normal Irradiance': Quantity(data[:,4], 'W/m2'), 'Diffuse Horizontal Irradiance': Quantity(data[:,5], 'W/m2')}
 
 	return data_dict, location
 
@@ -294,61 +261,72 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 	data, location = import_hourly_data(file_name)
 	#data, location = import_Chang_data(file_name)
 
-	latitude = location['Latitude (decimal degrees)']
-	longitude = location['Longitude (decimal degrees)']
+	# all the arguments, except the file_name, are Quantity objects
+	# all the angles below are Quantity objects, without the need to be 'self.'
+
+	latitude = Quantity(location['Latitude (decimal degrees)'], 'deg')
+	longitude = Quantity(location['Longitude (decimal degrees)'], 'deg')
+
+	if module_tilt is 'Default':
+		module_tilt = Quantity(np.abs(location['Latitude (decimal degrees)']), 'deg')
 
 	day_number = np.arange(1, len(data['Time']) + 1) / 24
 	#day_number = np.arange(0, len(data['Time'])) / 24
 
-	declination_angle = 23.45 * np.sin((day_number - 81) * 2 * np.pi / 365.)
-	hour_angle = (data['Time'] - 12) * 15 + longitude
+	declination_angle = Quantity(23.45 * np.sin((day_number - 81) * 2 * np.pi / 365.),'deg')
+	hour_angle = Quantity((data['Time'].unit['-'] - 12) * 15 + longitude.unit['deg'], 'deg')
 
-	altitude_angle = 360 / (2 * np.pi) * np.arcsin(np.sin(2 * np.pi / 360 * declination_angle) * 
-					 np.sin(2 * np.pi / 360 * latitude) + np.cos(2 * np.pi / 360 * declination_angle) * 
-					 np.cos(2 * np.pi / 360 * latitude) * np.cos(2 * np.pi / 360 * hour_angle))
+	altitude_angle = Quantity(
+					np.arcsin(np.sin(declination_angle.unit['rad']) * 
+					np.sin(latitude.unit('rad')) + np.cos(declination_angle.unit['rad']) * 
+					np.cos(latitude.unit('rad')) * np.cos(2 * np.pi / 360 * hour_angle)), 
+					'rad')
 
-	azimuth_angle = 360 / (2 * np.pi) * np.arccos((np.sin(2 * np.pi / 360 * declination_angle) * 
-					np.cos(2 * np.pi / 360 * latitude) - np.cos( 2 * np.pi / 360 * declination_angle) * 
-					np.sin(2 * np.pi / 360 * latitude) * np.cos(2 * np.pi / 360 * hour_angle)) / 
-					np.cos(2 * np.pi / 360 * altitude_angle)) * np.sign(hour_angle)
+	azimuth_angle = Quantity(
+					np.arccos((np.sin(declination_angle.unit['rad']) * 
+					np.cos(latitude.unit('rad')) - np.cos(declination_angle.unit['rad']) * 
+					np.sin(latitude.unit('rad')) * np.cos(hour_angle.unit['rad'])) / 
+					np.cos(altitude_angle.unit['rad'])) * np.sign(hour_angle.unit['rad']), 
+					'rad')
 
-	dni_fraction = np.cos(2 * np.pi / 360 * altitude_angle) * np.sin(2 * np.pi / 360 * 
-				   module_tilt) * np.cos(2 * np.pi / 360 * (array_azimuth - 
-				   azimuth_angle)) + np.sin(2 * np.pi / 360 * altitude_angle) * np.cos(2 * np.pi / 
-				   360 * module_tilt)
+	dni_fraction = np.cos(altitude_angle.unit['rad']) * np.sin(module_tilt.unit['rad']) * np.cos(array_azimuth.unit['rad'] - azimuth_angle.unit['rad']) + np.sin(altitude_angle.unit['rad']) * np.cos(module_tilt.unit['rad'])
+	
 	dni_fraction = dni_fraction.clip(min = 0)
 
-	direct_plane_radiation = data['Direct Normal Irradiance'] * dni_fraction
-	diffuse_plane_radiation = data['Diffuse Horizontal Irradiance'] * (180 - module_tilt) / 180
+	direct_plane_radiation = data['Direct Normal Irradiance'].unit['W/m2'] * dni_fraction
+	diffuse_plane_radiation = data['Diffuse Horizontal Irradiance'].unit['W/m2'] * (180 - module_tilt.unit['deg']) / 180
 	total_plane_radiation = direct_plane_radiation + diffuse_plane_radiation
 
-	cell_temperature = data['Temperature'] + (nominal_operating_temperature - 
+	cell_temperature = data['Temperature'].unit['degC'] + (nominal_operating_temperature.unit['degC'] - 
 					   20) * total_plane_radiation/800  #where does this formula come from?
 
-	temperature_derating = 1 + temperature_coefficient * (cell_temperature - 25)  # why the 25 correction?
+	temperature_derating = 1 + temperature_coefficient.unit['-/degC'] * (cell_temperature - 25)  # why the 25 correction?
 
-	power_kW = (temperature_derating * mismatch_derating * 
-					 dirt_derating * total_plane_radiation/1000)  # Converting W to kW
+	power = Quantity((temperature_derating * mismatch_derating.unit['-'] * 
+					 dirt_derating.unit['-'] * total_plane_radiation), 'W/m2')
 
-	sat_azimuth = np.sign(azimuth_angle) * 90
+	sat_azimuth = Quantity(np.sign(azimuth_angle.unit['rad']) * np.pi/2, 'rad')
 
-	sat_tilt = 360 / (2 * np.pi) * np.arctan(1 / np.tan(2 * np.pi / 360 * altitude_angle) * 
-			   np.cos( 2 * np.pi / 360 * (sat_azimuth - azimuth_angle)))
+	sat_tilt = Quantity(np.arctan(1 / np.tan(altitude_angle.unit['rad']) * 
+			   np.cos(sat_azimuth.unit['rad'] - azimuth_angle.unit['rad'])), 
+			   'rad')
 
-	sat_fraction = (np.cos(2 * np.pi / 360 * altitude_angle) * np.sin(2 * np.pi / 360 * sat_tilt) * 
-					np.cos(2 * np.pi / 360 * (sat_azimuth - azimuth_angle)) + np.sin(2 * np.pi / 360 * altitude_angle) * 
-					np.cos(2 * np.pi / 360 * sat_tilt))
+	sat_fraction = (np.cos(altitude_angle.unit['rad']) * np.sin(sat_tilt.unit['rad']) * 
+					np.cos(sat_azimuth.unit['rad'] - azimuth_angle.unit['rad']) + np.sin(altitude_angle.unit['rad']) * 
+					np.cos(sat_tilt.unit['rad']))
 	sat_fraction = sat_fraction.clip(min = 0)
 
-	sat_direct_POA = sat_fraction * data['Direct Normal Irradiance']
-	sat_diffuse_POA = data['Diffuse Horizontal Irradiance'] * (180 - sat_tilt) / 180
+	sat_direct_POA = sat_fraction * data['Direct Normal Irradiance'].unit['W/m2']
+	sat_diffuse_POA = data['Diffuse Horizontal Irradiance'].unit['W/m2'] * (180 - sat_tilt.unit['deg']) / 180
 	sat_total_POA = sat_direct_POA + sat_diffuse_POA
 
-	power_sat_kW = (temperature_derating * mismatch_derating * 
-					 dirt_derating * sat_total_POA / 1000)  # Convert W to kW
+	power_sat = Quantity(temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'] * sat_total_POA, 'W/m2')
 
-	power_dat_kW = (data['Direct Normal Irradiance'] * temperature_derating * 
-					mismatch_derating * dirt_derating / 1000)
+	power_dat = Quantity(data['Direct Normal Irradiance'].unit['W/m2'] * temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'], 'W/m2')
 
-	return power_kW, power_sat_kW, power_dat_kW
+	yearly_averaged_power = Quantity(np.sum(power.unit['W/m2'])/(365*24), 'W/m2') 
+	yearly_averaged_power_sat = Quantity(np.sum(power_sat.unit['W/m2'])/(365*24), 'W/m2')
+	yearly_averaged_power_dat = Quantity(np.sum(power_dat.unit['W/m2'])/(365*24), 'W/m2')
+
+	return power, power_sat, power_dat, yearly_averaged_power, yearly_averaged_power_sat, yearly_averaged_power_dat
 

--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -93,7 +93,7 @@ output_dict = {
 				"dimension": "energy / area",
 			},
 			"optional": False,
-			"description": "Hourly irradiation with no tracking per m2."
+			"description": "Hourly irradiation with no tracking per area."
 		},
 		"Horizontal single axis tracking": {
 			"Value": {
@@ -102,7 +102,7 @@ output_dict = {
 				"dimension": "energy / area",
 			},
 			"optional": False,
-			"description": "Hourly irradiation with single axis tracking per m2."
+			"description": "Hourly irradiation with single axis tracking per area."
 		},
 		"Two axis tracking": {
 			"Value": {
@@ -111,7 +111,7 @@ output_dict = {
 				"dimension": "energy / area",
 			},
 			"optional": False,
-			"description": "Hourly irradiation with two axis tracking per m2."
+			"description": "Hourly irradiation with two axis tracking per area."
 		},
 		"Mean solar input no tracking": {
 			"Value": {
@@ -120,7 +120,7 @@ output_dict = {
 				"dimension": "power / area",
 			},
 			"optional": False,
-			"description": "Mean solar input with no tracking."
+			"description": "Mean solar input with no tracking per area."
 		},
 		"Mean solar input single axis tracking": {
 			"Value": {
@@ -129,7 +129,7 @@ output_dict = {
 				"dimension": "power / area",
 			},
 			"optional": False,
-			"description": "Mean solar input with single axis tracking."
+			"description": "Mean solar input with single axis tracking per area."
 		},
 		"Mean solar input two axis tracking": {
 			"Value": {
@@ -138,7 +138,7 @@ output_dict = {
 				"dimension": "power / area",
 			},
 			"optional": False,
-			"description": "Mean solar input with two axis tracking."
+			"description": "Mean solar input with two axis tracking per area."
 		},
 	},
 }
@@ -223,10 +223,13 @@ def import_Chang_data(file_name):
 
 	data = read_textfile(file_name, delimiter = '	')
 
-	data_dict = {'Time': Quantity(data[:,0] - 10., '-'), 'Temperature': Quantity(data[:,1], 'degC'),
-				  'Direct Normal Irradiance': Quantity(data[:,2], 'W/m2'), 'Diffuse Horizontal Irradiance': Quantity(data[:,3], 'W/m2')}
+	data_dict = {'Time': Quantity(data[:,0] - 10., '-'), 
+				 'Temperature': Quantity(data[:,1], 'degC'),
+				 'Direct Normal Irradiance': Quantity(data[:,2], 'W/m2'), 
+				 'Diffuse Horizontal Irradiance': Quantity(data[:,3], 'W/m2')}
 
-	location = {'Latitude (decimal degrees)': -19.25, 'Longitude (decimal degrees)': 146.77}
+	location = {'Latitude (decimal degrees)': -19.25, 
+				'Longitude (decimal degrees)': 146.77}
 
 	return data_dict, location
 	
@@ -255,14 +258,22 @@ def import_hourly_data(file_name):
 			break
 	file_read.close()
 
-	data_dict = {'Time': Quantity(data[:,0], '-'), 'Temperature': Quantity(data[:,1], 'degC'), 'Global Horizontal Irradiance':  Quantity(data[:,3], 'W/m2'),
-				 'Direct Normal Irradiance': Quantity(data[:,4], 'W/m2'), 'Diffuse Horizontal Irradiance': Quantity(data[:,5], 'W/m2')}
+	data_dict = {'Time': Quantity(data[:,0], '-'), 
+				 'Temperature': Quantity(data[:,1], 'degC'), 
+				 'Global Horizontal Irradiance':  Quantity(data[:,3], 'W/m2'),
+				 'Direct Normal Irradiance': Quantity(data[:,4], 'W/m2'), 
+				 'Diffuse Horizontal Irradiance': Quantity(data[:,5], 'W/m2')}
 
 	return data_dict, location
 
 @lru_cache(maxsize = None)
-def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_operating_temperature,
-							 temperature_coefficient, mismatch_derating, dirt_derating):
+def calculate_PV_power_ratio(file_name, 
+							 module_tilt, 
+							 array_azimuth, 
+							 nominal_operating_temperature,
+							 temperature_coefficient, 
+							 mismatch_derating, 
+							 dirt_derating):
 	'''Calculation based on Chang 2020, https://doi.org/10.1016/j.xcrp.2020.100209
 	SAT: horzontal single axis tracking
 	DAT: dual axis tracking, no diffuse radiation
@@ -283,23 +294,37 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 	day_number = np.arange(1, len(data['Time'].unit['-']) + 1) / 24
 	#day_number = np.arange(0, len(data['Time'])) / 24
 
-	declination_angle = Quantity(23.45 * np.sin((day_number - 81) * 2 * np.pi / 365.),'deg')
+	declination_angle = Quantity(23.45 * np.sin((day_number - 81) * 2 * np.pi / 365.),'deg') # Cooper equation to calculate solar declination angle
 	hour_angle = Quantity((data['Time'].unit['-'] - 12) * 15 + longitude.unit['deg'], 'deg')
 
 	altitude_angle = Quantity(
-					np.arcsin(np.sin(declination_angle.unit['rad']) * 
-					np.sin(latitude.unit['rad']) + np.cos(declination_angle.unit['rad']) * 
-					np.cos(latitude.unit['rad']) * np.cos(hour_angle.unit['rad'])), 
-					'rad')
+						np.arcsin(
+							np.sin(declination_angle.unit['rad'])
+						    * np.sin(latitude.unit['rad']) 
+						    + np.cos(declination_angle.unit['rad']) 
+						    * np.cos(latitude.unit['rad']) 
+						    * np.cos(hour_angle.unit['rad'])
+						), 
+						'rad')
 
 	azimuth_angle = Quantity(
-					np.arccos((np.sin(declination_angle.unit['rad']) * 
-					np.cos(latitude.unit['rad']) - np.cos(declination_angle.unit['rad']) * 
-					np.sin(latitude.unit['rad']) * np.cos(hour_angle.unit['rad'])) / 
-					np.cos(altitude_angle.unit['rad'])) * np.sign(hour_angle.unit['rad']), 
-					'rad')
+						np.arccos(
+							(np.sin(declination_angle.unit['rad']) 
+						     * np.cos(latitude.unit['rad']) 
+						     - np.cos(declination_angle.unit['rad']) 
+							 * np.sin(latitude.unit['rad']) 
+							 * np.cos(hour_angle.unit['rad'])
+						     ) / 
+						     np.cos(altitude_angle.unit['rad'])
+						) * np.sign(hour_angle.unit['rad']), 
+						'rad')
 
-	dni_fraction = np.cos(altitude_angle.unit['rad']) * np.sin(module_tilt.unit['rad']) * np.cos(array_azimuth.unit['rad'] - azimuth_angle.unit['rad']) + np.sin(altitude_angle.unit['rad']) * np.cos(module_tilt.unit['rad'])
+	dni_fraction = (np.cos(altitude_angle.unit['rad']) 
+					* np.sin(module_tilt.unit['rad']) 
+					* np.cos(array_azimuth.unit['rad'] 
+				    - azimuth_angle.unit['rad']) 
+					+ np.sin(altitude_angle.unit['rad']) 
+					* np.cos(module_tilt.unit['rad']))
 	
 	dni_fraction = dni_fraction.clip(min = 0)
 
@@ -307,36 +332,65 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 	diffuse_plane_radiation = data['Diffuse Horizontal Irradiance'].unit['W/m2'] * (180 - module_tilt.unit['deg']) / 180
 	total_plane_radiation = direct_plane_radiation + diffuse_plane_radiation
 
-	cell_temperature = data['Temperature'].unit['degC'] + (nominal_operating_temperature.unit['degC'] - 
-					   20) * total_plane_radiation/800  
+	cell_temperature = (data['Temperature'].unit['degC'] 
+						+ (nominal_operating_temperature.unit['degC'] - 20) 
+						* total_plane_radiation/800)  
 
-	temperature_derating = 1 + temperature_coefficient.unit['-/delta_degC'] * (cell_temperature - 25)  
-
-	hourly_energy = Quantity((temperature_derating * mismatch_derating.unit['-'] * 
-					 dirt_derating.unit['-'] * total_plane_radiation), 'Wh/m2')
+	temperature_derating = 1 + temperature_coefficient.unit['1/delta_degC'] * (cell_temperature - 25)  
 
 	sat_azimuth = Quantity(np.sign(azimuth_angle.unit['rad']) * np.pi/2, 'rad')
 
-	sat_tilt = Quantity(np.arctan(1 / np.tan(altitude_angle.unit['rad']) * 
-			   np.cos(sat_azimuth.unit['rad'] - azimuth_angle.unit['rad'])), 
-			   'rad')
+	sat_tilt = Quantity(
+		           np.arctan(
+					   1 / np.tan(altitude_angle.unit['rad']) 
+				       * np.cos(sat_azimuth.unit['rad'] - azimuth_angle.unit['rad'])
+				   ), 
+			   	   'rad')
 
-	sat_fraction = (np.cos(altitude_angle.unit['rad']) * np.sin(sat_tilt.unit['rad']) * 
-					np.cos(sat_azimuth.unit['rad'] - azimuth_angle.unit['rad']) + np.sin(altitude_angle.unit['rad']) * 
-					np.cos(sat_tilt.unit['rad']))
+	sat_fraction = (np.cos(altitude_angle.unit['rad']) 
+					* np.sin(sat_tilt.unit['rad']) 
+					* np.cos(sat_azimuth.unit['rad'] - azimuth_angle.unit['rad']) 
+					+ np.sin(altitude_angle.unit['rad']) 
+					* np.cos(sat_tilt.unit['rad']))
 	sat_fraction = sat_fraction.clip(min = 0)
 
 	sat_direct_POA = sat_fraction * data['Direct Normal Irradiance'].unit['W/m2']
 	sat_diffuse_POA = data['Diffuse Horizontal Irradiance'].unit['W/m2'] * (180 - sat_tilt.unit['deg']) / 180
 	sat_total_POA = sat_direct_POA + sat_diffuse_POA
 
-	hourly_energy_sat = Quantity(temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'] * sat_total_POA, 'Wh/m2')
+	hourly_energy = Quantity(temperature_derating 
+						     * mismatch_derating.unit['-'] 
+						     * dirt_derating.unit['-'] 
+						     * total_plane_radiation, 
+					'Wh/m2')
+								 
+	hourly_energy_sat = Quantity(temperature_derating 
+								 * mismatch_derating.unit['-'] 
+								 * dirt_derating.unit['-'] 
+								 * sat_total_POA, 
+						'Wh/m2')
 
-	hourly_energy_dat = Quantity(data['Direct Normal Irradiance'].unit['W/m2'] * temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'], 'Wh/m2')
+	hourly_energy_dat = Quantity(data['Direct Normal Irradiance'].unit['W/m2'] 
+								 * temperature_derating 
+								 * mismatch_derating.unit['-'] 
+								 * dirt_derating.unit['-'], 
+						'Wh/m2')
 
-	yearly_averaged_power = Quantity(np.sum(hourly_energy.unit['Wh/m2']), 'Wh_per_year/m2') 
-	yearly_averaged_power_sat = Quantity(np.sum(hourly_energy_sat.unit['Wh/m2']), 'Wh_per_year/m2')
-	yearly_averaged_power_dat = Quantity(np.sum(hourly_energy_dat.unit['Wh/m2']), 'Wh_per_year/m2')
+	
+	# Summing hourly energy data and dividing by 1 year to get average power
+	time_for_averaging = Quantity(1., 'year')
+								 
+	yearly_averaged_power = Quantity(np.sum(hourly_energy.unit['J/m2']) / time_for_averaging.unit['s'], 
+							'W/m2') 							 
+	yearly_averaged_power_sat = Quantity(np.sum(hourly_energy_sat.unit['J/m2']) / time_for_averaging.unit['s'], 
+							    'W/m2')
+	yearly_averaged_power_dat = Quantity(np.sum(hourly_energy_dat.unit['J/m2']) / time_for_averaging.unit['s'], 
+								'W/m2')
 
-	return hourly_energy, hourly_energy_sat, hourly_energy_dat, yearly_averaged_power, yearly_averaged_power_sat, yearly_averaged_power_dat
+	return (hourly_energy, 
+			hourly_energy_sat, 
+			hourly_energy_dat, 
+			yearly_averaged_power, 
+			yearly_averaged_power_sat, 
+			yearly_averaged_power_dat)
 

--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -197,7 +197,7 @@ class Hourly_Irradiation_Plugin:
 		 self.yearly_averaged_power, 
 		 self.yearly_averaged_power_sat, 
 		 self.yearly_averaged_power_dat) = calculate_PV_power_ratio(
-												pv['Hourly Irradiation']['File']['Value'],
+												self.input_dict_resolved['Hourly Irradiation']['File']['Value'],
 												tilt, 
 												pv['Array azimuth']['Value'],
 												pv['Nominal operating temperature']['Value'], 

--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -73,10 +73,10 @@ input_dict = {
 		"Temperature coefficient": {
 			"Value": {
 				"type": {float,},
-				"bounds": (-0.1, 0), 
+				"bounds": (-0.5, 0.5), 
 			},
 			"Unit": {
-				"dimension": "dimensionless/temperature_diff",
+				"dimension": "1/temperature_diff",
 			},
 			"optional": False,
 			"description": "Performance decrease of irradiated module per degree increase."
@@ -185,16 +185,26 @@ class Hourly_Irradiation_Plugin:
 		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Hourly_Irradiation_Plugin')
 
 		pv = self.input_dict_resolved['Irradiance Area Parameters']
+		
 		if 'Module tilt' in pv:
 			tilt = pv['Module tilt']['Value']
 		else: # if we want to make the tilt equal to latitude, we don't point it through a path in the input fiale, we let it be the default
 			tilt = 'Default' 
 
-		self.hourly_energy, self.hourly_energy_sat, self.hourly_energy_dat, self.yearly_averaged_power, self.yearly_averaged_power_sat, self.yearly_averaged_power_dat = calculate_PV_power_ratio(dcf.inp['Hourly Irradiation']['File']['Value'],
-											tilt, pv['Array azimuth']['Value'],
-											pv['Nominal operating temperature']['Value'], 
-											pv['Temperature coefficient']['Value'],
-											pv['Mismatch derating']['Value'], pv['Dirt derating']['Value'])
+		(self.hourly_energy, 
+		 self.hourly_energy_sat, 
+		 self.hourly_energy_dat, 
+		 self.yearly_averaged_power, 
+		 self.yearly_averaged_power_sat, 
+		 self.yearly_averaged_power_dat) = calculate_PV_power_ratio(
+												pv['Hourly Irradiation']['File']['Value'],
+												tilt, 
+												pv['Array azimuth']['Value'],
+												pv['Nominal operating temperature']['Value'], 
+												pv['Temperature coefficient']['Value'],
+												pv['Mismatch derating']['Value'], 
+			 									pv['Dirt derating']['Value']
+												)
 
 		output_inserter_function(output_dict, self, dcf, 'Hourly_Irradiation_Plugin') 
 

--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -324,9 +324,9 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 
 	power_dat = Quantity(data['Direct Normal Irradiance'].unit['W/m2'] * temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'], 'W/m2')
 
-	yearly_averaged_power = Quantity(np.sum(power.unit['W/m2'])/(365*24), 'W/m2') 
-	yearly_averaged_power_sat = Quantity(np.sum(power_sat.unit['W/m2'])/(365*24), 'W/m2')
-	yearly_averaged_power_dat = Quantity(np.sum(power_dat.unit['W/m2'])/(365*24), 'W/m2')
+	yearly_averaged_power = Quantity(np.sum(power.unit['W/m2']), 'Wh_per_year/m2') 
+	yearly_averaged_power_sat = Quantity(np.sum(power_sat.unit['W/m2']), 'Wh_per_year/m2')
+	yearly_averaged_power_dat = Quantity(np.sum(power_dat.unit['W/m2']), 'Wh_per_year/m2')
 
 	return power, power_sat, power_dat, yearly_averaged_power, yearly_averaged_power_sat, yearly_averaged_power_dat
 

--- a/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
+++ b/src/pyH2A/Plugins/Hourly_Irradiation_Plugin.py
@@ -88,27 +88,27 @@ output_dict = {
 	"Hourly Irradiation": {
 		"No tracking": {
 			"Value": {
-				"inserted_value": "power",
+				"inserted_value": "hourly_energy",
 				"type": {np.ndarray,},
-				"dimension": "power / area",
+				"dimension": "energy / area",
 			},
 			"optional": False,
 			"description": "Hourly irradiation with no tracking per m2."
 		},
 		"Horizontal single axis tracking": {
 			"Value": {
-				"inserted_value": "power_sat",
+				"inserted_value": "hourly_energy_sat",
 				"type": {np.ndarray,},
-				"dimension": "power / area",
+				"dimension": "energy / area",
 			},
 			"optional": False,
 			"description": "Hourly irradiation with single axis tracking per m2."
 		},
 		"Two axis tracking": {
 			"Value": {
-				"inserted_value": "power_dat",
+				"inserted_value": "hourly_energy_dat",
 				"type": {np.ndarray,},
-				"dimension": "power / area",
+				"dimension": "energy / area",
 			},
 			"optional": False,
 			"description": "Hourly irradiation with two axis tracking per m2."
@@ -167,11 +167,11 @@ class Hourly_Irradiation_Plugin:
 	Returns
 	-------
 	Hourly Irradiation > No tracking > Value : ndarray
-		Hourly irradiation poer with no tracking per area.
+		Hourly irradiation energy with no tracking per area.
 	Hourly Irradiation > Horizontal single axis tracking > Value : ndarray
-		Hourly irradiation power with single axis tracking per area.
+		Hourly irradiation energy with single axis tracking per area.
 	Hourly Irradiation > Two axis tracking > Value : ndarray
-		Hourly irradiation power with two axis tracking per area.
+		Hourly irradiation energy with two axis tracking per area.
 	Hourly Irradiation > Mean solar input > Value : float
 		Mean solar input power with no tracking in per area.
 	Hourly Irradiation > Mean solar input, single axis tracking > Value : float
@@ -190,7 +190,7 @@ class Hourly_Irradiation_Plugin:
 		else: # if we want to make the tilt equal to latitude, we don't point it through a path in the input fiale, we let it be the default
 			tilt = 'Default' 
 
-		self.power, self.power_sat, self.power_dat, self.yearly_averaged_power, self.yearly_averaged_power_sat, self.yearly_averaged_power_dat = calculate_PV_power_ratio(dcf.inp['Hourly Irradiation']['File']['Value'],
+		self.hourly_energy, self.hourly_energy_sat, self.hourly_energy_dat, self.yearly_averaged_power, self.yearly_averaged_power_sat, self.yearly_averaged_power_dat = calculate_PV_power_ratio(dcf.inp['Hourly Irradiation']['File']['Value'],
 											tilt, pv['Array azimuth']['Value'],
 											pv['Nominal operating temperature']['Value'], 
 											pv['Temperature coefficient']['Value'],
@@ -302,8 +302,8 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 
 	temperature_derating = 1 + temperature_coefficient.unit['-/delta_degC'] * (cell_temperature - 25)  
 
-	power = Quantity((temperature_derating * mismatch_derating.unit['-'] * 
-					 dirt_derating.unit['-'] * total_plane_radiation), 'W/m2')
+	hourly_energy = Quantity((temperature_derating * mismatch_derating.unit['-'] * 
+					 dirt_derating.unit['-'] * total_plane_radiation), 'Wh/m2')
 
 	sat_azimuth = Quantity(np.sign(azimuth_angle.unit['rad']) * np.pi/2, 'rad')
 
@@ -320,13 +320,13 @@ def calculate_PV_power_ratio(file_name, module_tilt, array_azimuth, nominal_oper
 	sat_diffuse_POA = data['Diffuse Horizontal Irradiance'].unit['W/m2'] * (180 - sat_tilt.unit['deg']) / 180
 	sat_total_POA = sat_direct_POA + sat_diffuse_POA
 
-	power_sat = Quantity(temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'] * sat_total_POA, 'W/m2')
+	hourly_energy_sat = Quantity(temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'] * sat_total_POA, 'Wh/m2')
 
-	power_dat = Quantity(data['Direct Normal Irradiance'].unit['W/m2'] * temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'], 'W/m2')
+	hourly_energy_dat = Quantity(data['Direct Normal Irradiance'].unit['W/m2'] * temperature_derating * mismatch_derating.unit['-'] * dirt_derating.unit['-'], 'Wh/m2')
 
-	yearly_averaged_power = Quantity(np.sum(power.unit['W/m2']), 'Wh_per_year/m2') 
-	yearly_averaged_power_sat = Quantity(np.sum(power_sat.unit['W/m2']), 'Wh_per_year/m2')
-	yearly_averaged_power_dat = Quantity(np.sum(power_dat.unit['W/m2']), 'Wh_per_year/m2')
+	yearly_averaged_power = Quantity(np.sum(hourly_energy.unit['Wh/m2']), 'Wh_per_year/m2') 
+	yearly_averaged_power_sat = Quantity(np.sum(hourly_energy_sat.unit['Wh/m2']), 'Wh_per_year/m2')
+	yearly_averaged_power_dat = Quantity(np.sum(hourly_energy_dat.unit['Wh/m2']), 'Wh_per_year/m2')
 
-	return power, power_sat, power_dat, yearly_averaged_power, yearly_averaged_power_sat, yearly_averaged_power_dat
+	return hourly_energy, hourly_energy_sat, hourly_energy_dat, yearly_averaged_power, yearly_averaged_power_sat, yearly_averaged_power_dat
 

--- a/src/tests/plugins/hourly_irradiation_plugin_test.py
+++ b/src/tests/plugins/hourly_irradiation_plugin_test.py
@@ -49,9 +49,9 @@ class DummyDCF:
             "expected": {
                 "latitude": Quantity(34.859,"deg"),
                 "longitude": Quantity(-116.889,"deg"),
-                "mean_power_dat": Quantity(6.801704863179404/24.,"kW/m2"), # the original value was kWh/m2/day, which is not supported, so we divide by 24 to have equivalent kWh/m2
-                "mean_power": Quantity(5.499228123213646/24.,"kW/m2"),
-                "mean_power_sat": Quantity(6.8301271595436885/24.,"kW/m2"),
+                "mean_power_dat": Quantity(6.801704863179404,"kWh_per_day/m2"), 
+                "mean_power": Quantity(5.499228123213646,"kWh_per_day/m2"),
+                "mean_power_sat": Quantity(6.8301271595436885,"kWh_per_day/m2"),
             },
         },
     ],

--- a/src/tests/plugins/hourly_irradiation_plugin_test.py
+++ b/src/tests/plugins/hourly_irradiation_plugin_test.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from pyH2A.Utilities.Unit_Handler.quantity import Quantity
 from pyH2A.Plugins.Hourly_Irradiation_Plugin import (
     Hourly_Irradiation_Plugin,
     import_hourly_data,
@@ -22,12 +23,12 @@ class DummyDCF:
         self.inp = {
             "Hourly Irradiation": {"File": {"Value": hourly_file}},
             "Irradiance Area Parameters": {
-                "Module Tilt (degrees)": {"Value": module_tilt},
-                "Array Azimuth (degrees)": {"Value": array_azimuth},
-                "Nominal Operating Temperature (Celsius)": {"Value": nominal_temp},
-                "Mismatch Derating": {"Value": mismatch_derating},
-                "Dirt Derating": {"Value": dirt_derating},
-                "Temperature Coefficient (per Celsius)": {"Value": temp_coeff},
+                "Module tilt": {"Value": module_tilt, "Unit":"deg"}, # we can actually comment-out this line, it's just the latitude, which is the default
+                "Array azimuth": {"Value": array_azimuth, "Unit":"deg"},
+                "Nominal operating temperature": {"Value": nominal_temp, "Unit":"degC"},
+                "Mismatch derating": {"Value": mismatch_derating, "Unit":"-"},
+                "Dirt derating": {"Value": dirt_derating, "Unit":"-"},
+                "Temperature coefficient": {"Value": temp_coeff, "Unit":"-/delta_degC"},
             },
         }
 
@@ -39,18 +40,18 @@ class DummyDCF:
             "input": {
                 "hourly_file": "pyH2A.Lookup_Tables.Hourly_Irradiation_Data~tmy_34.859_-116.889_2006_2015.csv",
                 "module_tilt": 34.859,
-                "array_azimuth": 180,
-                "nominal_temp": 45,
+                "array_azimuth": 180.,
+                "nominal_temp": 45.,
                 "mismatch_derating": 0.98,
                 "dirt_derating": 0.98,
                 "temp_coeff": -0.004,
             },
             "expected": {
-                "latitude": 34.859,
-                "longitude": -116.889,
-                "mean_power_dat_kW": 6.801704863179404,
-                "mean_power_kW": 5.499228123213646,
-                "mean_power_sat_kW": 6.8301271595436885,
+                "latitude": Quantity(34.859,"deg"),
+                "longitude": Quantity(-116.889,"deg"),
+                "mean_power_dat": Quantity(6.801704863179404/24.,"kW/m2"), # the original value was kWh/m2/day, which is not supported, so we divide by 24 to have equivalent kWh/m2
+                "mean_power": Quantity(5.499228123213646/24.,"kW/m2"),
+                "mean_power_sat": Quantity(6.8301271595436885/24.,"kW/m2"),
             },
         },
     ],
@@ -69,17 +70,17 @@ def test_hourly_irradiation_plugin(case):
     # Tolerance (very small)
     tolerance = 1e-12
 
-    assert np.sum(plugin.power_dat_kW) / 365.0 == pytest.approx(
-        expected["mean_power_dat_kW"],
+    assert plugin.yearly_averaged_power_dat.unit["W/m2"] == pytest.approx(
+        expected["mean_power_dat"].unit["W/m2"],
         abs=tolerance
     )
-    assert np.sum(plugin.power_kW) / 365.0 == pytest.approx(
-        expected["mean_power_kW"],
+    assert plugin.yearly_averaged_power.unit["W/m2"] == pytest.approx(
+        expected["mean_power"].unit["W/m2"],
         abs=tolerance    
     )
-    assert np.sum(plugin.power_sat_kW) / 365.0 == pytest.approx(
-        expected["mean_power_sat_kW"],
+    assert plugin.yearly_averaged_power_sat.unit["W/m2"] == pytest.approx(
+        expected["mean_power_sat"].unit["W/m2"],
         abs=tolerance
     )
-    assert location["Latitude (decimal degrees)"] == expected["latitude"]
-    assert location["Longitude (decimal degrees)"] == expected["longitude"]
+    assert location["Latitude (decimal degrees)"] == expected["latitude"].unit['deg']
+    assert location["Longitude (decimal degrees)"] == expected["longitude"].unit['deg']

--- a/src/tests/plugins/hourly_irradiation_plugin_test.py
+++ b/src/tests/plugins/hourly_irradiation_plugin_test.py
@@ -23,12 +23,12 @@ class DummyDCF:
         self.inp = {
             "Hourly Irradiation": {"File": {"Value": hourly_file}},
             "Irradiance Area Parameters": {
-                "Module tilt": {"Value": module_tilt, "Unit":"deg"}, # we can actually comment-out this line, it's just the latitude, which is the default
-                "Array azimuth": {"Value": array_azimuth, "Unit":"deg"},
-                "Nominal operating temperature": {"Value": nominal_temp, "Unit":"degC"},
-                "Mismatch derating": {"Value": mismatch_derating, "Unit":"-"},
-                "Dirt derating": {"Value": dirt_derating, "Unit":"-"},
-                "Temperature coefficient": {"Value": temp_coeff, "Unit":"-/delta_degC"},
+                "Module tilt": {"Value": module_tilt, "Unit" : "deg"}, # we can actually comment-out this line, it's just the latitude, which is the default
+                "Array azimuth": {"Value": array_azimuth, "Unit" : "deg"},
+                "Nominal operating temperature": {"Value": nominal_temp, "Unit" : "degC"},
+                "Mismatch derating": {"Value": mismatch_derating, "Unit" : "-"},
+                "Dirt derating": {"Value": dirt_derating, "Unit" : "-"},
+                "Temperature coefficient": {"Value": temp_coeff, "Unit" : "1/delta_degC"},
             },
         }
 
@@ -49,9 +49,9 @@ class DummyDCF:
             "expected": {
                 "latitude": Quantity(34.859,"deg"),
                 "longitude": Quantity(-116.889,"deg"),
-                "mean_power_dat": Quantity(6.801704863179404,"kWh_per_day/m2"), 
-                "mean_power": Quantity(5.499228123213646,"kWh_per_day/m2"),
-                "mean_power_sat": Quantity(6.8301271595436885,"kWh_per_day/m2"),
+                "mean_power_dat": Quantity(6.801704863179404 * 1000./24., "W/m2"), # Conversion from kWh/m2/day to W/m2 through multiplication with 1000/24
+                "mean_power": Quantity(5.499228123213646 * 1000./24., "W/m2"),
+                "mean_power_sat": Quantity(6.8301271595436885 * 1000./24., "W/m2"),
             },
         },
     ],


### PR DESCRIPTION
# Refactor hourly irradiation plugin

# Description

- Insert output_dict
- Adapt the code to use IO resolver. This one required some changes in the logic because the original version enabled to process some inputs (including the latitude), then insert them, then process other inputs, which enabled to make the Tilt angle value point to the latitude. 
This is no longer possible with the "input resolver - calculation - output inserter" logic. 
So I introduced a default value for the tilt: when it's absent from the input file, we make it equal to the latitude automatically. It means that we should no longer fill the input file with a path pointing to the latitude, but just remove the Tilt row altogether when we want it to be equal to latitude. Of course, if we want to specify an explicit numerical value, it's still possible.
- update plugin test
- update docstrings


# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [x] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [x] Design / Architecture change


# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [ ] Unit tests
- [ ] Integration tests
- [ ] Performance tests
- [x] Manual tests / example model runs

## Test Details:
plugin test runs fine locally

# Checklist
- [x] Code follows pyH2A style guidelines
- [x] Self-review of code completed
- [x] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [x] No new warnings generated
- [x] Tests added / updated and passing
- [ ] Dependent changes merged and published
