### PR TITLE
Insert "Unit" bottom key (equal to "year") in ``construction time``

### DIFF
--- a/src/pyH2A/Discounted_Cash_Flow.py
+++ b/src/pyH2A/Discounted_Cash_Flow.py
@@ -402,7 +402,9 @@ class Discounted_Cash_Flow:
 
 		insert(self, 'Financial Input Values', 'construction time', 'Value', 
 			   len(self.inp['Construction']), __name__, print_info = self.print_info)
-
+		insert(self, 'Financial Input Values', 'construction time', 'Unit', 
+			   'year', __name__, print_info = self.print_info)
+		
 		construction_start = self.fin['startup year']['Value'] - self.fin['construction time']['Value']
 		end_of_life = self.fin['startup year']['Value'] + self.fin['plant life']['Value']
 


### PR DESCRIPTION
# Insert "Unit" bottom key (equal to "year") in ``construction time``

# Note 
Maybe we want to use this PR to perform other modifications in DCF , if needed, to make the code compatible with the new Quantity-based logic

# Description
- add ``insert(self, 'Financial Input Values', 'construction time', 'Unit', 'year', __name__, print_info = self.print_info)`` in discounted_cash_flow 


# Motivation / Background
This is needed because the plugins that have this variable as an input expect a unit, to build the Quantity when calling the input_resolver.
Even though inside the plugin we can, in practice, cal dcf.inp['Financial Input Values']['construction time']['Value'] (we never really need the resolved value), the simple fact that this is in the input dict implies that a missing "Unit" key would make the input_resolver fail


# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [X] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change

# How Has This Been Tested?
Not tested as such, but will be needed for some plugins tests (and end-to-end tests) to work



# Checklist
- [X] Code follows pyH2A style guidelines
- [X] Self-review of code completed
