### PR TITLE
Make sum_table and sum_all_tables handle Quantity objects

### DIFF
--- a/src/pyH2A/Utilities/input_modification.py
+++ b/src/pyH2A/Utilities/input_modification.py
@@ -822,7 +822,7 @@ def sum_all_tables(dictionary, table_group, bottom_key, insert_total = False,
 	for key in dictionary:
 
 		if table_group in key:
-			value = sum_table(dictionary, key, bottom_key, path_key = path_key) # value is a Quantity object
+			value = sum_table(dictionary, key, bottom_key) # value is a Quantity object
 			total += value.base_value
 			contributions['Data'][key] = value.base_value
 			base_unit = value.base_unit

--- a/src/pyH2A/Utilities/input_modification.py
+++ b/src/pyH2A/Utilities/input_modification.py
@@ -818,6 +818,7 @@ def sum_all_tables(dictionary, table_group, bottom_key, insert_total = False,
 	total = 0.
 	contributions = {}
 	contributions['Data'] = {}
+	base_unit = 'USD'
 
 	for key in dictionary:
 

--- a/src/pyH2A/Utilities/input_modification.py
+++ b/src/pyH2A/Utilities/input_modification.py
@@ -750,7 +750,7 @@ def process_table(dictionary, top_key, bottom_key, path_key = 'Path',
 						  path_key = path_key[-1], add_processed = True,
 						  print_processing_warning = print_processing_warning)
 
-def sum_table(dictionary, top_key, bottom_key, path_key = 'Path'):
+def sum_table(dictionary, top_key, bottom_key):
 	'''For the provided `dictionary`, all entries in dictionary[top_key] are processed 
 	using ``process_input()`` (positions: top_key > key > bottom key) and summed.
 
@@ -762,16 +762,15 @@ def sum_table(dictionary, top_key, bottom_key, path_key = 'Path'):
 		Top key.
 	bottom_key : str, ndarray or list
 		Bottom key.
-	path_key : str, optional
-		Key used for path column. Defaults to 'Path'.
 	'''
 
 	value = 0.
 
 	for key in dictionary[top_key]:
-		value += process_input(dictionary, top_key, key, bottom_key, path_key = path_key)
+		value += dictionary[top_key][key][bottom_key].base_value
+		base_unit = dictionary[top_key][key][bottom_key].base_unit
 
-	return value
+	return Quantity(value, base_unit)
 
 def sum_all_tables(dictionary, table_group, bottom_key, insert_total = False, 
 				   class_object = None, middle_key_insertion = 'Summed Total', 
@@ -823,16 +822,18 @@ def sum_all_tables(dictionary, table_group, bottom_key, insert_total = False,
 	for key in dictionary:
 
 		if table_group in key:
-			value = sum_table(dictionary, key, bottom_key, path_key = path_key)
-			total += value
-			contributions['Data'][key] = value
+			value = sum_table(dictionary, key, bottom_key, path_key = path_key) # value is a Quantity object
+			total += value.base_value
+			contributions['Data'][key] = value.base_value
+			base_unit = value.base_unit
 
 			if insert_total is True:
 				insert(class_object, key, middle_key_insertion, bottom_key_insertion, 
-					    value, __name__, print_info = print_info)
+					    value.base_value, __name__, print_info = print_info)
 
 	contributions['Total'] = total
 	contributions['Table Group'] = table_group
+	total = Quantity(total, base_unit)
 
 	if return_contributions is True:
 		return total, contributions


### PR DESCRIPTION
# Make sum_table and sum_all_tables handle Quantity objects

# Description

- sum_tables now expects a Quantity as an input, and sums up the values before returning a Quantity
- in sum_all_tables, only ``total`` is returned as a Quantity ; for the moment, the non-plugin parts of pyH2A, which might use the contributions, can't handle Quantities so it stays floats for the moment
- in the same way, when we insert the value, it has to be a float


# Note
I gave ``base_unit``  a default (initial) assignment in ``sum_all_tables``. Indeed, when no table of the group is found in the input file, no ``base_unit`` will be assigned in the ``if`` condition, making the code fail upon Quantity generation. 
- The problem is that this default base_unit is arbitrary. I chose USD because in practice that's how we use the sum_all_tables so far, but in principle this is a problem: if we later return a Quantity that is (0, 'USD') for something that should have been (0, 'something else'), a new failure will appear.
- Just having an empty table wouldn't solve the problem, because we need this table to include a unit somewhere. And forcing users to specify a dummy row with a value of 0 and the correct unit of the table is really not a nice solution.
- The cleanest solution would certainly be to explicitly specify the unit as an input parameter of the sum_all_tables call, as I had made in a previous verison. So that even when we don't have a table, we can return a clean Quantity(0, 'whatever unit')

# Motivation / Background
- We now pass Quantities in plugins

# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [X] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change

# How Has This Been Tested?
Tested locally by putting together the present modification, and the variable operating cost plugin test: it runs fine

# Checklist
- [X] Code follows pyH2A style guidelines
- [X] Self-review of code completed
- [X] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [ ] No new warnings generated
- [ ] Tests added / updated and passing
- [ ] Dependent changes merged and published
