### PR TITLE
Refactor: Update the plugin and test - Capital Cost Plugin

### DIFF
--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -7,14 +7,14 @@ input_dict = {
 	"<...> Direct Capital Cost <...>": {
 		"<...>": {
 			"Value": {
-				"type": {float,},
+				"type": {int, float,},
 				"bounds": (0, None),
 			},
 			"Unit": {
 				"dimension": "currency",
 			},	
 			"optional": True,
-			"description": "Direct capital cost contribution, summed for each individual table in 'Direct Capital Cost' group."
+			"description": "Individual entry of direct capital cost."
 		},
         'sum_tables': {
             'mode': 'all',
@@ -30,14 +30,14 @@ input_dict = {
 	"<...> Indirect Capital Cost <...>": {
 		"<...>": {
 			"Value": {
-				"type": {float,},
+				"type": {int, float,},
 				"bounds": (0, None),
 			},	
 			"Unit": {
 				"dimension": "currency",
 			},		
 			"optional": True,
-			"description": "Indirect capital cost contribution, summed for each individual table in 'Indirect Capital Cost' group."
+			"description": "Individual entry of indirect capital cost."
 		},
         'sum_tables': {
             'mode': 'all',
@@ -53,7 +53,7 @@ input_dict = {
 	"Non-Depreciable Capital Costs": {
 		"Cost of land": {
 			"Value": {
-				"type": {float,},
+				"type": {int, float,},
 				"bounds": (0, None),
 			},	
 			"Unit": {
@@ -64,27 +64,27 @@ input_dict = {
 		},
 		"Land required": {
 			"Value": {
-				"type": {float,},
+				"type": {int, float,},
 				"bounds": (0, None),
 			},	
 			"Unit": {
 				"dimension": "area",
 			},		
 			"optional": False,
-			"description": "Total land Area are required."
+			"description": "Total land area are required."
 		},
 	},
 	"<...> Other Non-Depreciable Capital Cost <...>": {
 		"<...>": {
 			"Value": {
-				"type": {float,},
+				"type": {int, float,},
 				"bounds": (0, None),
 			},	
 			"Unit": {
 				"dimension": "currency",
 			},		
 			"optional": True,
-			"description": "Other non-depreciable capital cost contribution, summed for each individual table in 'Other Non-Depreciable Capital Cost' group."
+			"description": "Individual entry of other non-depreciable capital cost."
 		},
         'sum_tables': {
             'mode': 'all',
@@ -104,53 +104,48 @@ output_dict = {
 		"Inflated": {
 			"Value": {
 				"inserted_value": "direct_inflated",
-				"type": {float,},
+				"type": {int, float,},
 				"dimension": "currency",
 			},
 			"description": "Total direct capital costs multiplied by combined inflator.",
-			"optional": False,
 		},
 	},
 	"Indirect Capital Costs": {
 		"Inflated": {
 			"Value": {
 				"inserted_value": "indirect_inflated",
-				"type": {float,},
+				"type": {int,float,},
 				"dimension": "currency",
 			},
 			"description": "Total indirect capital costs multiplied by combined inflator.",
-			"optional": False,
 		},
 	},
 	"Non-Depreciable Capital Costs": {
 		"Total": {
 			"Value": {	
 				"inserted_value": "non_depreciable",
-				"type": {float,},
+				"type": {int, float,},
 				"dimension": "currency",		
 			},
 			"description": "Total non-depreciable capital costs.",
-			"optional": False,
 		},
 		"Inflated": {
 			"Value": {
 				"inserted_value": "non_depreciable_inflated",
-				"type": {float,},
+				"type": {int, float,},
 				"dimension": "currency",
 			},
 			"description": "Total non-depreciable capital costs multiplied by combined inflator.",
-			"optional": False,
 		},
 	},
 	"Depreciable Capital Costs": {
 		"Total": {
 			"Value": {
 				"inserted_value": "depreciable",
-				"type": {float,},
+				"type": {int, float,},
 				"dimension": "currency",
 			},	
-			"description": "Total depreciable capital costs.",
-			"optional": False,
+			"description": "Total depreciable capital costs (direct + indirect capital costs).",
 		},		
 		"Inflated": {
 			"Value": {
@@ -158,8 +153,7 @@ output_dict = {
 				"type": {float,},	
 				"dimension": "currency",
 			},	
-			"description": "Total depreciable capital costs multiplied by combined inflator.",
-			"optional": False,
+			"description": "Total depreciable capital costs (direct + indirect capital costs) multiplied by combined inflator.",
 		},
 	},
 	"Total Capital Costs": {
@@ -169,8 +163,7 @@ output_dict = {
 				"type": {float,},
 				"dimension": "currency",
 			},	
-			"description": "Total capital costs.",
-			"optional": False,
+			"description": "Total capital costs (depreciable + non-depreciable capital costs).",
 		},
 		"Inflated": {
 			"Value": {
@@ -178,8 +171,7 @@ output_dict = {
 				"type": {float,},
 				"dimension": "currency",
 			},
-			"description": "Total capital costs multiplied by combined inflator.",
-			"optional": False,	
+			"description": "Total capital costs (depreciable + non-depreciable capital costs) multiplied by combined inflator.",
 		},
 	},
 	"special_insertions":
@@ -187,55 +179,100 @@ output_dict = {
             "<...> Direct Capital Cost <...>": {
                 "Summed total": {
                     "Value": {
-                        "type": {float},
+                        "type": {int, float},
+						"dimension": "currency"
                     },
-                    "optional": False,
                     "description": "Summed total of direct capital costs for each table"
                 },
             },
             "<...> Indirect Capital Cost <...>": {
                 "Summed total": {
                     "Value": {
-                        "type": {float},
+                        "type": {int, float},
+						"dimension": "currency"
                     },
-                    "optional": False,
                     "description": "Summed total of indirect capital costs for each table"
                 },
             },
             "<...> Other Non-Depreciable Capital Cost <...>": {
                 "Summed total": {
                     "Value": {
-                        "type": {float},
+                        "type": {int, float},
+						"dimension": "currency"
                     },
-                    "optional": False,
                     "description": "Summed total of other non-depreciable capital costs for each table"
                 },
             },
             "Direct Capital Cost": {
+				"Summed total": {
+					"Value": {
+						"type": {int, float},
+						"dimension": "currency"
+					},
+					"description": "Summed total of this table."
+				},
                 "Summed group total": {
                     "Value": {
-                        "type": {float},
+                        "type": {int, float},
+						"dimension": "currency"
                     },
-                    "optional": False,
                     "description": "Summed total of direct capital costs across all tables"
+                },
+				'Contributions': {
+                    'Value': {
+                        'type': {dict},
+                        'dimension': 'currency',
+                    },
+                    'description': 'Contributions to the sum'
                 },
             },
             "Indirect Capital Cost": {
+				"Summed total": {
+					"Value": {
+						"type": {int, float},
+						"dimension": "currency"
+					},
+					"optional": False,
+					"description": "Summed total of this table."
+				},
                 "Summed group total": {
                     "Value": {
-                        "type": {float},
+                        "type": {int, float},
+						"dimension": "currency"
                     },
                     "optional": False,
                     "description": "Summed total of indirect capital costs across all tables"
                 },
+				'Contributions': {
+                    'Value': {
+                        'type': {dict},
+                        'dimension': 'currency',
+                    },
+                    'description': 'Contributions to the sum'
+                },
             },
             "Other Non-Depreciable Capital Cost": {
+				"Summed total": {
+					"Value": {
+						"type": {int, float},
+						"dimension": "currency"
+					},
+					"optional": False,
+					"description": "Summed total of this table."
+				},
                 "Summed group total": {
                     "Value": {
-                        "type": {float},
+                        "type": {int, float},
+                        "dimension": "currency"
                     },
-                    "optional": False,
                     "description": "Summed total of other non-depreciable capital costs across all tables"
+                },
+				'Contributions': {
+                    'Value': {
+                        'type': {dict},
+                        'dimension': 'currency',
+                    },
+                    'description': 'Contributions to the sum'
                 },
             },			
         },
@@ -294,47 +331,45 @@ class Capital_Cost_Plugin:
 	def __init__(self, dcf, print_info):
 		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Capital_Cost_Plugin')
 		
-		# Except for self.direct and self.indirect, which are natively Quantities as they are the results of sum_all_tables calls, 
-		# all the self.X variable are converted into Quantites just before their insertion, to avoid unnecessary complications
-		self.direct = self.input_dict_resolved['Direct Capital Cost']['Summed group total']['Value'] # Calculated during the call of sum_tables
-		direct_inflated = self.direct.unit['USD'] * dcf.combined_inflator		
-		self.indirect = self.input_dict_resolved['Indirect Capital Cost']['Summed group total']['Value'] # Calculated during the call of sum_tables
-		indirect_inflated = self.indirect.unit['USD'] * dcf.combined_inflator
-
-		depreciable = self.direct.unit['USD'] + self.indirect.unit['USD']
-		depreciable_inflated = direct_inflated + indirect_inflated
+		direct_capital_costs = self.input_dict_resolved['Direct Capital Cost']['Summed group total']['Value'] # Calculated during the call of sum_tables
+		indirect_capital_costs = self.input_dict_resolved['Indirect Capital Cost']['Summed group total']['Value'] # Calculated during the call of sum_tables
 		
-		non_depreciable = self.non_depreciable_capital_costs(dcf, print_info)
+		self.direct_inflated = Quantity(direct_capital_costs.unit['USD'] 
+								  		* dcf.combined_inflator, 
+								'USD')
+		self.indirect_inflated = Quantity(indirect_capital_costs.unit['USD'] 
+										  * dcf.combined_inflator, 
+								'USD')
 
-		non_depreciable_inflated = non_depreciable * dcf.ci_inflator
-		total = depreciable + non_depreciable
-		total_inflated = depreciable_inflated + non_depreciable_inflated
+		self.depreciable = Quantity(direct_capital_costs.unit['USD'] 
+							        + indirect_capital_costs.unit['USD'], 
+							'USD')
+		self.depreciable_inflated = Quantity(self.depreciable.unit['USD'] 
+										  * dcf.combined_inflator, 
+								    'USD')
 
-		# convert the values into Quantities
-		self.direct_inflated = Quantity(direct_inflated, 'USD')
-		self.indirect_inflated = Quantity(indirect_inflated, 'USD')
-		self.depreciable = Quantity(depreciable, 'USD')
-		self.depreciable_inflated = Quantity(depreciable_inflated, 'USD')
-		self.non_depreciable = Quantity(non_depreciable, 'USD')
-		self.non_depreciable_inflated = Quantity(non_depreciable_inflated, 'USD')        
-		self.total = Quantity(total, 'USD')
-		self.total_inflated = Quantity(total_inflated, 'USD')     
-
-		print(' direct', self.direct.unit['USD'])	
-		print(' indirect', self.indirect.unit['USD'])	
-		print(' dep', self.depreciable.unit['USD'])	
-		print(' nondep', self.non_depreciable.unit['USD'])			
-		print(' total', self.total.unit['USD'])			
+		self.non_depreciable = self.non_depreciable_capital_costs()
+		self.non_depreciable_inflated = Quantity(self.non_depreciable.unit['USD'] 
+										         * dcf.ci_inflator, 
+								         'USD')
+		
+		self.total = Quantity(self.depreciable.unit['USD'] 
+							  + self.non_depreciable.unit['USD'],
+					 'USD')
+		self.total_inflated = Quantity(self.depreciable_inflated.unit['USD'] 
+									 + self.non_depreciable_inflated.unit['USD'],
+							  'USD')
+		
 		output_inserter_function(output_dict, self, dcf, 'Capital_Cost_Plugin')
 
-
-	def non_depreciable_capital_costs(self, dcf, print_info):
+	def non_depreciable_capital_costs(self):
 		'''Calculation of non-depreciable capital costs by calculating cost of land and 
 			obtaining the total of the "Other Non-Depreciable Capital Cost" group.
 		'''
 
-		non_depreciable = self.input_dict_resolved['Non-Depreciable Capital Costs']
-		non_depreciable = non_depreciable['Cost of land']['Value'].unit['USD/m2'] * non_depreciable['Land required']['Value'].unit['m2']
-		non_depreciable += self.input_dict_resolved['Other Non-Depreciable Capital Cost']['Summed group total']['Value'].unit['USD']
+		non_depreciable_costs = (self.input_dict_resolved['Non-Depreciable Capital Costs']['Cost of land']['Value'].unit['USD/m2'] 
+						   		 * self.input_dict_resolved['Non-Depreciable Capital Costs']['Land required']['Value'].unit['m2'])
 
-		return non_depreciable
+		non_depreciable_costs += self.input_dict_resolved['Other Non-Depreciable Capital Cost']['Summed group total']['Value'].unit['USD']
+
+		return Quantity(non_depreciable_costs, 'USD')

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -1,4 +1,7 @@
-from pyH2A.Utilities.input_modification import insert, sum_all_tables, process_table
+from pyH2A.Utilities.input_modification import sum_all_tables
+from pyH2A.Utilities.IO import input_resolver_function, output_inserter_function
+from pyH2A.Utilities.Unit_Handler.quantity import Quantity
+import numpy as np
 
 input_dict = {
 	"<...> Direct Capital Cost <...>": {
@@ -65,7 +68,6 @@ input_dict = {
 		},
 	}
 }
-
 
 output_dict = {
 	"Direct Capital Costs": {
@@ -173,7 +175,7 @@ output_dict = {
             "<...> Direct Capital Cost <...>": {
                 "Summed Total": {
                     "Value": {
-                        "type": {int, float},
+                        "type": {float},
                     },
                     "optional": True,
                     "description": "Summed total of direct capital costs across all tables"
@@ -182,7 +184,7 @@ output_dict = {
             "<...> Indirect Capital Cost <...>": {
                 "Summed Total": {
                     "Value": {
-                        "type": {int, float},
+                        "type": {float},
                     },
                     "optional": True,
                     "description": "Summed total of indirect capital costs across all tables"
@@ -191,7 +193,7 @@ output_dict = {
             "<...> Other Non-Depreciable Capital Cost <...>": {
                 "Summed Total": {
                     "Value": {
-                        "type": {int, float},
+                        "type": {float},
                     },
                     "optional": True,
                     "description": "Summed total of other non-depreciable capital costs across all tables"
@@ -248,59 +250,55 @@ class Capital_Cost_Plugin:
 	['Capital_Cost_Plugin'].direct_contributions : dict
 		Attribute containing cost contributions for "Direct Capital Cost" group.
 	'''
-	def __init__(self, dcf, print_info):
-
+		def __init__(self, dcf, print_info):
+		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Capital_Cost_Plugin')
+        
+		# All the self.X variable are converted into Quantites just before their insertion, to avoid unnecessary complications
 		self.direct_capital_costs(dcf, print_info)  
-		direct_inflated = self.direct * dcf.combined_inflator
-
-		insert(dcf, 'Direct Capital Costs', 'Total', 'Value', self.direct, __name__, print_info = print_info)
-		insert(dcf, 'Direct Capital Costs', 'Inflated', 'Value', direct_inflated, __name__, print_info = print_info)
-
+		self.direct_inflated = self.direct * dcf.combined_inflator
+        
 		self.indirect_capital_costs(dcf, print_info)
-
-		indirect_inflated = self.indirect * dcf.combined_inflator
-		depreciable = self.direct + self.indirect
-		depreciable_inflated = direct_inflated + indirect_inflated
-		
-		insert(dcf, 'Indirect Capital Costs', 'Total', 'Value', self.indirect, __name__, print_info = print_info)
-		insert(dcf, 'Indirect Capital Costs', 'Inflated', 'Value', indirect_inflated, __name__, print_info = print_info)
-		
-		insert(dcf, 'Depreciable Capital Costs', 'Total', 'Value', depreciable, __name__, print_info = print_info)
-		insert(dcf, 'Depreciable Capital Costs', 'Inflated', 'Value', depreciable_inflated, __name__, print_info = print_info)
-		
+		self.indirect_inflated = self.indirect * dcf.combined_inflator
+		self.depreciable = self.direct + self.indirect
+		self.depreciable_inflated = self.direct_inflated + self.indirect_inflated
+        
 		self.non_depreciable_capital_costs(dcf, print_info)
+		self.non_depreciable_inflated = self.non_depreciable * dcf.ci_inflator
+		self.total = self.depreciable + self.non_depreciable
+		self.total_inflated = self.depreciable_inflated + self.non_depreciable_inflated
 
-		non_depreciable_inflated = self.non_depreciable * dcf.ci_inflator
-		total = depreciable + self.non_depreciable
-		total_inflated = depreciable_inflated + non_depreciable_inflated
+		# convert the values into Quantities
+		self.direct = Quantity(self.direct, 'USD')
+		self.direct_inflated = Quantity(self.direct_inflated, 'USD')
+		self.indirect = Quantity(self.indirect, 'USD')
+		self.indirect_inflated = Quantity(self.indirect_inflated, 'USD')
+		self.depreciable = Quantity(self.depreciable, 'USD')
+		self.depreciable_inflated = Quantity(self.depreciable_inflated, 'USD')
+		self.non_depreciable = Quantity(self.non_depreciable, 'USD')
+		self.non_depreciable_inflated = Quantity(self.non_depreciable_inflated, 'USD')        
+		self.total = Quantity(self.total, 'USD')
+		self.total_inflated = Quantity(self.total_inflated, 'USD')     
 
-		insert(dcf, 'Non-Depreciable Capital Costs', 'Total', 'Value', self.non_depreciable, __name__, print_info = print_info)
-		insert(dcf, 'Non-Depreciable Capital Costs', 'Inflated', 'Value', non_depreciable_inflated, __name__, print_info = print_info)
-		
-		insert(dcf, 'Total Capital Costs', 'Total', 'Value', total, __name__, print_info = print_info)
-		insert(dcf, 'Total Capital Costs', 'Inflated', 'Value', total_inflated, __name__, print_info = print_info)
-
+		output_inserter_function(output_dict, self, dcf, 'Capital_Cost_Plugin')
+        
 	def direct_capital_costs(self, dcf, print_info):
 		'''Calculation of direct capital costs by applying ``sum_all_tables()`` to "Direct Capital Cost" group.'''
-
-		self.direct, self.direct_contributions = sum_all_tables(dcf.inp, 'Direct Capital Cost', 'Value', insert_total = True, 
-																class_object = dcf, print_info = print_info, 
-																return_contributions = True)
+                                                               
+		self.direct, self.direct_contributions = sum_all_tables(self.input_dict_resolved, 'Direct Capital Cost', 'Value', insert_total = True, 
+																class_object = dcf, print_info = print_info, return_contributions = True, unit = 'USD')
 
 	def indirect_capital_costs(self, dcf, print_info):
 		'''Calculation of indirect capital costs by applying ``sum_all_tables()`` to "Indirect Capital Cost" group.'''
 
-		self.indirect = sum_all_tables(dcf.inp, 'Indirect Capital Cost', 'Value', insert_total = True, 
-									   class_object = dcf, print_info = print_info)
+		self.indirect = sum_all_tables(self.input_dict_resolved, 'Indirect Capital Cost', 'Value', insert_total = True, 
+									   class_object = dcf, print_info = print_info, unit = 'USD')
 
 	def non_depreciable_capital_costs(self, dcf, print_info):
 		'''Calculation of non-depreciable capital costs by calculating cost of land and applying
 		``sum_all_tables()`` to "Other Non-Depreciable Capital Cost" group.
 		'''
 
-		process_table(dcf.inp, 'Non-Depreciable Capital Costs', 'Value')
-
-		non_depreciable = dcf.inp['Non-Depreciable Capital Costs']
-		self.non_depreciable = non_depreciable['Cost of land ($ per acre)']['Value'] * non_depreciable['Land required (acres)']['Value']
-		self.non_depreciable += sum_all_tables(dcf.inp, 'Other Non-Depreciable Capital Cost', 'Value', insert_total = True, class_object = dcf, print_info = print_info)
+		non_depreciable = self.input_dict_resolved['Non-Depreciable Capital Costs']
+		self.non_depreciable = non_depreciable['Cost of land']['Value'].unit['USD/m2'] * non_depreciable['Land required']['Value'].unit['m2']
+		self.non_depreciable += sum_all_tables(self.input_dict_resolved, 'Other Non-Depreciable Capital Cost', 'Value', insert_total = True, class_object = dcf, print_info = print_info, unit = 'USD')
 

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -213,9 +213,9 @@ class Capital_Cost_Plugin:
 	<...> Indirect Capital Cost <...> >> Value : float
 		``sum_all_tables()`` is used.
 	Non-Depreciable Capital Costs > Cost of land > Value : float
-		Cost of land in $ per acre, ``process_table()`` is used.
+		Cost of land, ``process_table()`` is used.
 	Non-Depreciable Capital Costs > Land required > Value : float
-		Total land are required in acres, ``process_table()`` is used.
+		Total land are required, ``process_table()`` is used.
 	<...> Other Non-Depreciable Capital Cost <...> >> Value : float
 		``sum_all_tables()`` is used.
 

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -177,7 +177,7 @@ output_dict = {
                     "Value": {
                         "type": {float},
                     },
-                    "optional": True,
+                    "optional": False,
                     "description": "Summed total of direct capital costs across all tables"
                 },
             },
@@ -186,7 +186,7 @@ output_dict = {
                     "Value": {
                         "type": {float},
                     },
-                    "optional": True,
+                    "optional": False,
                     "description": "Summed total of indirect capital costs across all tables"
                 },
             },
@@ -195,7 +195,7 @@ output_dict = {
                     "Value": {
                         "type": {float},
                     },
-                    "optional": True,
+                    "optional": False,
                     "description": "Summed total of other non-depreciable capital costs across all tables"
                 },
             },
@@ -213,9 +213,9 @@ class Capital_Cost_Plugin:
 	<...> Indirect Capital Cost <...> >> Value : float
 		``sum_all_tables()`` is used.
 	Non-Depreciable Capital Costs > Cost of land > Value : float
-		Cost of land, ``process_table()`` is used.
+		Cost of land.
 	Non-Depreciable Capital Costs > Land required > Value : float
-		Total land are required, ``process_table()`` is used.
+		Total land area required.
 	<...> Other Non-Depreciable Capital Cost <...> >> Value : float
 		``sum_all_tables()`` is used.
 

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -208,24 +208,24 @@ class Capital_Cost_Plugin:
 
 	Parameters
 	----------
-	[...] Direct Capital Cost [...] >> Value : float
+	<...> Direct Capital Cost <...> >> Value : float
 		``sum_all_tables()`` is used.
-	[...] Indirect Capital Cost [...] >> Value : float
+	<...> Indirect Capital Cost <...> >> Value : float
 		``sum_all_tables()`` is used.
-	Non-Depreciable Capital Costs > Cost of land ($ per acre) > Value : float
+	Non-Depreciable Capital Costs > Cost of land > Value : float
 		Cost of land in $ per acre, ``process_table()`` is used.
-	Non-Depreciable Capital Costs > Land required (acres) > Value : float
+	Non-Depreciable Capital Costs > Land required > Value : float
 		Total land are required in acres, ``process_table()`` is used.
-	[...] Other Non-Depreciable Capital Cost [...] >> Value : float
+	<...> Other Non-Depreciable Capital Cost <...> >> Value : float
 		``sum_all_tables()`` is used.
 
 	Returns
 	-------
-	[...] Direct Capital Cost [...] > Summed Total > Value : float
+	<...> Direct Capital Cost <...> > Summed Total > Value : float
 		Summed total for each individual table in "Direct Capital Cost" group.
-	[...] Indirect Capital Cost [...] > Summed Total > Value : float
+	<...> Indirect Capital Cost <...> > Summed Total > Value : float
 		Summed total for each individual table in "Indirect Capital Cost" group.
-	[...] Other Non-Depreciable Capital Cost  [...] > Summed Total > Value : float
+	<...> Other Non-Depreciable Capital Cost  <...> > Summed Total > Value : float
 		Summed total for each individual table in "Other Non-Depreciable Capital Cost" group.
 	Direct Capital Costs > Total > Value : float
 		Total direct capital costs.
@@ -279,7 +279,7 @@ class Capital_Cost_Plugin:
 		self.total = Quantity(self.total, 'USD')
 		self.total_inflated = Quantity(self.total_inflated, 'USD')     
 
-	output_inserter_function(output_dict, self, dcf, 'Capital_Cost_Plugin')
+		output_inserter_function(output_dict, self, dcf, 'Capital_Cost_Plugin')
         
 	def direct_capital_costs(self, dcf, print_info):
 		'''Calculation of direct capital costs by applying ``sum_all_tables()`` to "Direct Capital Cost" group.'''
@@ -301,4 +301,3 @@ class Capital_Cost_Plugin:
 		non_depreciable = self.input_dict_resolved['Non-Depreciable Capital Costs']
 		self.non_depreciable = non_depreciable['Cost of land']['Value'].unit['USD/m2'] * non_depreciable['Land required']['Value'].unit['m2']
 		self.non_depreciable += sum_all_tables(self.input_dict_resolved, 'Other Non-Depreciable Capital Cost', 'Value', insert_total = True, class_object = dcf, print_info = print_info, unit = 'USD')
-

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -71,7 +71,7 @@ output_dict = {
 	"Direct Capital Costs": {
 		"Total": {
 			"Value": {
-				"inserted_value": "currency",
+				"inserted_value": "direct",
 				"type": {float,},	
 				"dimension": "currency",
 			},
@@ -80,7 +80,7 @@ output_dict = {
 		},
 		"Inflated": {
 			"Value": {
-				"inserted_value": "currency",
+				"inserted_value": "direct_inflated",
 				"type": {float,},
 				"dimension": "currency",
 			},
@@ -91,7 +91,7 @@ output_dict = {
 	"Indirect Capital Costs": {
 		"Total": {
 			"Value": {
-				"inserted_value": "currency",
+				"inserted_value": "indirect",
 				"type": {float,},
 				"dimension": "currency",
 			},
@@ -100,7 +100,7 @@ output_dict = {
 		},
 		"Inflated": {
 			"Value": {
-				"inserted_value": "currency",
+				"inserted_value": "indirect_inflated",
 				"type": {float,},
 				"dimension": "currency",
 			},
@@ -111,7 +111,7 @@ output_dict = {
 	"Non-Depreciable Capital Costs": {
 		"Total": {
 			"Value": {	
-				"inserted_value": "currency",
+				"inserted_value": "non_depreciable",
 				"type": {float,},
 				"dimension": "currency",		
 			},
@@ -120,7 +120,7 @@ output_dict = {
 		},
 		"Inflated": {
 			"Value": {
-				"inserted_value": "currency",	
+				"inserted_value": "non_depreciable_inflated",
 				"type": {float,},
 				"dimension": "currency",
 			},
@@ -131,7 +131,7 @@ output_dict = {
 	"Depreciable Capital Costs": {
 		"Total": {
 			"Value": {
-				"inserted_value": "currency",
+				"inserted_value": "depreciable",
 				"type": {float,},
 				"dimension": "currency",
 			},	
@@ -140,7 +140,7 @@ output_dict = {
 		},
 		"Inflated": {
 			"Value": {
-				"inserted_value": "currency",
+				"inserted_value": "depreciable_inflated",
 				"type": {float,},	
 				"dimension": "currency",
 			},	
@@ -151,7 +151,7 @@ output_dict = {
 	"Total Capital Costs": {
 		"Total": {
 			"Value": {
-				"inserted_value": "currency",
+				"inserted_value": "total",
 				"type": {float,},
 				"dimension": "currency",
 			},	
@@ -160,7 +160,7 @@ output_dict = {
 		},
 		"Inflated": {
 			"Value": {
-				"inserted_value": "currency",
+				"inserted_value": "total_inflated",
 				"type": {float,},
 				"dimension": "currency",
 			},

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -16,6 +16,16 @@ input_dict = {
 			"optional": True,
 			"description": "Direct capital cost contribution, summed for each individual table in 'Direct Capital Cost' group."
 		},
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed total',
+                'middle_key_total_group_insertion': 'Summed group total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },		
 	},
 	"<...> Indirect Capital Cost <...>": {
 		"<...>": {
@@ -29,6 +39,16 @@ input_dict = {
 			"optional": True,
 			"description": "Indirect capital cost contribution, summed for each individual table in 'Indirect Capital Cost' group."
 		},
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed total',
+                'middle_key_total_group_insertion': 'Summed group total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },			
 	},
 	"Non-Depreciable Capital Costs": {
 		"Cost of land": {
@@ -66,20 +86,21 @@ input_dict = {
 			"optional": True,
 			"description": "Other non-depreciable capital cost contribution, summed for each individual table in 'Other Non-Depreciable Capital Cost' group."
 		},
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed total',
+                'middle_key_total_group_insertion': 'Summed group total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },			
 	}
 }
 
 output_dict = {
 	"Direct Capital Costs": {
-		"Total": {
-			"Value": {
-				"inserted_value": "direct",
-				"type": {float,},	
-				"dimension": "currency",
-			},
-			"description": "Total direct capital costs.",
-			"optional": False,
-		},
 		"Inflated": {
 			"Value": {
 				"inserted_value": "direct_inflated",
@@ -91,15 +112,6 @@ output_dict = {
 		},
 	},
 	"Indirect Capital Costs": {
-		"Total": {
-			"Value": {
-				"inserted_value": "indirect",
-				"type": {float,},
-				"dimension": "currency",
-			},
-			"description": "Total indirect capital costs.",
-			"optional": False,
-		},
 		"Inflated": {
 			"Value": {
 				"inserted_value": "indirect_inflated",
@@ -131,15 +143,6 @@ output_dict = {
 		},
 	},
 	"Depreciable Capital Costs": {
-		"Total": {
-			"Value": {
-				"inserted_value": "depreciable",
-				"type": {float,},
-				"dimension": "currency",
-			},	
-			"description": "Total depreciable capital costs.",
-			"optional": False,
-		},
 		"Inflated": {
 			"Value": {
 				"inserted_value": "depreciable_inflated",
@@ -173,7 +176,34 @@ output_dict = {
 	"special_insertions":
         {"sum_all_tables": {
             "<...> Direct Capital Cost <...>": {
-                "Summed Total": {
+                "Summed total": {
+                    "Value": {
+                        "type": {float},
+                    },
+                    "optional": False,
+                    "description": "Summed total of direct capital costs for each table"
+                },
+            },
+            "<...> Indirect Capital Cost <...>": {
+                "Summed total": {
+                    "Value": {
+                        "type": {float},
+                    },
+                    "optional": False,
+                    "description": "Summed total of indirect capital costs for each table"
+                },
+            },
+            "<...> Other Non-Depreciable Capital Cost <...>": {
+                "Summed total": {
+                    "Value": {
+                        "type": {float},
+                    },
+                    "optional": False,
+                    "description": "Summed total of other non-depreciable capital costs for each table"
+                },
+            },
+            "Direct Capital Cost": {
+                "Summed group total": {
                     "Value": {
                         "type": {float},
                     },
@@ -181,8 +211,8 @@ output_dict = {
                     "description": "Summed total of direct capital costs across all tables"
                 },
             },
-            "<...> Indirect Capital Cost <...>": {
-                "Summed Total": {
+            "Indirect Capital Cost": {
+                "Summed group total": {
                     "Value": {
                         "type": {float},
                     },
@@ -190,15 +220,15 @@ output_dict = {
                     "description": "Summed total of indirect capital costs across all tables"
                 },
             },
-            "<...> Other Non-Depreciable Capital Cost <...>": {
-                "Summed Total": {
+            "Other Non-Depreciable Capital Cost": {
+                "Summed group total": {
                     "Value": {
                         "type": {float},
                     },
                     "optional": False,
                     "description": "Summed total of other non-depreciable capital costs across all tables"
                 },
-            },
+            },			
         },
     },
 }
@@ -221,11 +251,11 @@ class Capital_Cost_Plugin:
 
 	Returns
 	-------
-	<...> Direct Capital Cost <...> > Summed Total > Value : float
+	<...> Direct Capital Cost <...> > Summed total > Value : float
 		Summed total for each individual table in "Direct Capital Cost" group.
-	<...> Indirect Capital Cost <...> > Summed Total > Value : float
+	<...> Indirect Capital Cost <...> > Summed total > Value : float
 		Summed total for each individual table in "Indirect Capital Cost" group.
-	<...> Other Non-Depreciable Capital Cost  <...> > Summed Total > Value : float
+	<...> Other Non-Depreciable Capital Cost  <...> > Summed total > Value : float
 		Summed total for each individual table in "Other Non-Depreciable Capital Cost" group.
 	Direct Capital Costs > Total > Value : float
 		Total direct capital costs.
@@ -255,42 +285,37 @@ class Capital_Cost_Plugin:
 		
 		# Except for self.direct and self.indirect, which are natively Quantities as they are the results of sum_all_tables calls, 
 		# all the self.X variable are converted into Quantites just before their insertion, to avoid unnecessary complications
-		self.direct_capital_costs(dcf, print_info)  
-		self.direct_inflated = self.direct.unit['USD'] * dcf.combined_inflator
+		self.direct = self.input_dict_resolved['Direct Capital Cost']['Summed group total']['Value'] # Calculated during the call of sum_tables
+		direct_inflated = self.direct.unit['USD'] * dcf.combined_inflator		
+		self.indirect = self.input_dict_resolved['Indirect Capital Cost']['Summed group total']['Value'] # Calculated during the call of sum_tables
+		indirect_inflated = self.indirect.unit['USD'] * dcf.combined_inflator
+
+		depreciable = self.direct.unit['USD'] + self.indirect.unit['USD']
+		depreciable_inflated = direct_inflated + indirect_inflated
 		
-		self.indirect_capital_costs(dcf, print_info)
-		self.indirect_inflated = self.indirect.unit['USD'] * dcf.combined_inflator
-		self.depreciable = self.direct.unit['USD'] + self.indirect.unit['USD']
-		self.depreciable_inflated = self.direct_inflated + self.indirect_inflated
-		
-		self.non_depreciable_capital_costs(dcf, print_info)
-		self.non_depreciable_inflated = self.non_depreciable * dcf.ci_inflator
-		self.total = self.depreciable + self.non_depreciable
-		self.total_inflated = self.depreciable_inflated + self.non_depreciable_inflated
+		non_depreciable = self.non_depreciable_capital_costs(dcf, print_info)
+
+		non_depreciable_inflated = non_depreciable * dcf.ci_inflator
+		total = depreciable + non_depreciable
+		total_inflated = depreciable_inflated + non_depreciable_inflated
 
 		# convert the values into Quantities
-		self.direct_inflated = Quantity(self.direct_inflated, 'USD')
-		self.indirect_inflated = Quantity(self.indirect_inflated, 'USD')
-		self.depreciable = Quantity(self.depreciable, 'USD')
-		self.depreciable_inflated = Quantity(self.depreciable_inflated, 'USD')
-		self.non_depreciable = Quantity(self.non_depreciable, 'USD')
-		self.non_depreciable_inflated = Quantity(self.non_depreciable_inflated, 'USD')        
-		self.total = Quantity(self.total, 'USD')
-		self.total_inflated = Quantity(self.total_inflated, 'USD')     
+		self.direct_inflated = Quantity(direct_inflated, 'USD')
+		self.indirect_inflated = Quantity(indirect_inflated, 'USD')
+		self.depreciable = Quantity(depreciable, 'USD')
+		self.depreciable_inflated = Quantity(depreciable_inflated, 'USD')
+		self.non_depreciable = Quantity(non_depreciable, 'USD')
+		self.non_depreciable_inflated = Quantity(non_depreciable_inflated, 'USD')        
+		self.total = Quantity(total, 'USD')
+		self.total_inflated = Quantity(total_inflated, 'USD')     
 
+		print(' direct', self.direct.unit['USD'])	
+		print(' indirect', self.indirect.unit['USD'])	
+		print(' dep', self.depreciable.unit['USD'])	
+		print(' nondep', self.non_depreciable.unit['USD'])			
+		print(' total', self.total.unit['USD'])			
 		output_inserter_function(output_dict, self, dcf, 'Capital_Cost_Plugin')
-        
-	def direct_capital_costs(self, dcf, print_info):
-		'''Calculation of direct capital costs by applying ``sum_all_tables()`` to "Direct Capital Cost" group.'''
-                                                               
-		self.direct, self.direct_contributions = sum_all_tables(self.input_dict_resolved, 'Direct Capital Cost', 'Value', insert_total = True, 
-																class_object = dcf, print_info = print_info, return_contributions = True)
 
-	def indirect_capital_costs(self, dcf, print_info):
-		'''Calculation of indirect capital costs by applying ``sum_all_tables()`` to "Indirect Capital Cost" group.'''
-
-		self.indirect = sum_all_tables(self.input_dict_resolved, 'Indirect Capital Cost', 'Value', insert_total = True, 
-									   class_object = dcf, print_info = print_info)
 
 	def non_depreciable_capital_costs(self, dcf, print_info):
 		'''Calculation of non-depreciable capital costs by calculating cost of land and applying
@@ -298,5 +323,7 @@ class Capital_Cost_Plugin:
 		'''
 
 		non_depreciable = self.input_dict_resolved['Non-Depreciable Capital Costs']
-		self.non_depreciable = non_depreciable['Cost of land']['Value'].unit['USD/m2'] * non_depreciable['Land required']['Value'].unit['m2']
-		self.non_depreciable += sum_all_tables(self.input_dict_resolved, 'Other Non-Depreciable Capital Cost', 'Value', insert_total = True, class_object = dcf, print_info = print_info).unit['USD']
+		non_depreciable = non_depreciable['Cost of land']['Value'].unit['USD/m2'] * non_depreciable['Land required']['Value'].unit['m2']
+		non_depreciable += self.input_dict_resolved['Other Non-Depreciable Capital Cost']['Summed group total']['Value'].unit['USD']
+
+		return non_depreciable

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -143,6 +143,15 @@ output_dict = {
 		},
 	},
 	"Depreciable Capital Costs": {
+		"Total": {
+			"Value": {
+				"inserted_value": "depreciable",
+				"type": {float,},
+				"dimension": "currency",
+			},	
+			"description": "Total depreciable capital costs.",
+			"optional": False,
+		},		
 		"Inflated": {
 			"Value": {
 				"inserted_value": "depreciable_inflated",
@@ -239,15 +248,15 @@ class Capital_Cost_Plugin:
 	Parameters
 	----------
 	<...> Direct Capital Cost <...> >> Value : float
-		``sum_all_tables()`` is used.
+		``sum_all_tables()`` is used in the input resolver.
 	<...> Indirect Capital Cost <...> >> Value : float
-		``sum_all_tables()`` is used.
+		``sum_all_tables()`` is used in the input resolver.
 	Non-Depreciable Capital Costs > Cost of land > Value : float
 		Cost of land.
 	Non-Depreciable Capital Costs > Land required > Value : float
 		Total land area required.
 	<...> Other Non-Depreciable Capital Cost <...> >> Value : float
-		``sum_all_tables()`` is used.
+		``sum_all_tables()`` is used in the input resolver.
 
 	Returns
 	-------
@@ -257,12 +266,14 @@ class Capital_Cost_Plugin:
 		Summed total for each individual table in "Indirect Capital Cost" group.
 	<...> Other Non-Depreciable Capital Cost  <...> > Summed total > Value : float
 		Summed total for each individual table in "Other Non-Depreciable Capital Cost" group.
-	Direct Capital Costs > Total > Value : float
-		Total direct capital costs.
+	Direct Capital Cost > Summed group total > Value : float
+		Summed total for all the tables in "Direct Capital Cost" group.
+	Indirect Capital Cost > Summed group total > Value : float
+		Summed total for all the tables in "Indirect Capital Cost" group.
+	Other Non-Depreciable Capital Cost > Summed group total > Value : float
+		Summed total for all the tables in "Other Non-Depreciable Capital Cost" group.		
 	Direct Capital Costs > Inflated > Value : float
 		Total direct capital costs multiplied by combined inflator.
-	Indirect Capital Costs > Total > Value : float
-		Total indirect capital costs.
 	Indirect Capital Costs > Inflated > Value : float
 		Total indirect capital costs multiplied by combined inflator.
 	Non-Depreciable Capital Costs > Total > Value : float
@@ -318,8 +329,8 @@ class Capital_Cost_Plugin:
 
 
 	def non_depreciable_capital_costs(self, dcf, print_info):
-		'''Calculation of non-depreciable capital costs by calculating cost of land and applying
-		``sum_all_tables()`` to "Other Non-Depreciable Capital Cost" group.
+		'''Calculation of non-depreciable capital costs by calculating cost of land and 
+			obtaining the total of the "Other Non-Depreciable Capital Cost" group.
 		'''
 
 		non_depreciable = self.input_dict_resolved['Non-Depreciable Capital Costs']

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -66,6 +66,141 @@ input_dict = {
 	}
 }
 
+
+output_dict = {
+	"Direct Capital Costs": {
+		"Total": {
+			"Value": {
+				"inserted_value": "currency",
+				"type": {float,},	
+				"dimension": "currency",
+			},
+			"description": "Total direct capital costs.",
+			"optional": False,
+		},
+		"Inflated": {
+			"Value": {
+				"inserted_value": "currency",
+				"type": {float,},
+				"dimension": "currency",
+			},
+			"description": "Total direct capital costs multiplied by combined inflator.",
+			"optional": False,
+		},
+	},
+	"Indirect Capital Costs": {
+		"Total": {
+			"Value": {
+				"inserted_value": "currency",
+				"type": {float,},
+				"dimension": "currency",
+			},
+			"description": "Total indirect capital costs.",
+			"optional": False,
+		},
+		"Inflated": {
+			"Value": {
+				"inserted_value": "currency",
+				"type": {float,},
+				"dimension": "currency",
+			},
+			"description": "Total indirect capital costs multiplied by combined inflator.",
+			"optional": False,
+		},
+	},
+	"Non-Depreciable Capital Costs": {
+		"Total": {
+			"Value": {	
+				"inserted_value": "currency",
+				"type": {float,},
+				"dimension": "currency",		
+			},
+			"description": "Total non-depreciable capital costs.",
+			"optional": False,
+		},
+		"Inflated": {
+			"Value": {
+				"inserted_value": "currency",	
+				"type": {float,},
+				"dimension": "currency",
+			},
+			"description": "Total non-depreciable capital costs multiplied by combined inflator.",
+			"optional": False,
+		},
+	},
+	"Depreciable Capital Costs": {
+		"Total": {
+			"Value": {
+				"inserted_value": "currency",
+				"type": {float,},
+				"dimension": "currency",
+			},	
+			"description": "Total depreciable capital costs.",
+			"optional": False,
+		},
+		"Inflated": {
+			"Value": {
+				"inserted_value": "currency",
+				"type": {float,},	
+				"dimension": "currency",
+			},	
+			"description": "Total depreciable capital costs multiplied by combined inflator.",
+			"optional": False,
+		},
+	},
+	"Total Capital Costs": {
+		"Total": {
+			"Value": {
+				"inserted_value": "currency",
+				"type": {float,},
+				"dimension": "currency",
+			},	
+			"description": "Total capital costs.",
+			"optional": False,
+		},
+		"Inflated": {
+			"Value": {
+				"inserted_value": "currency",
+				"type": {float,},
+				"dimension": "currency",
+			},
+			"description": "Total capital costs multiplied by combined inflator.",
+			"optional": False,	
+		},
+	},
+	"special_insertions":
+        {"sum_all_tables": {
+            "<...> Direct Capital Cost <...>": {
+                "Summed Total": {
+                    "Value": {
+                        "type": {int, float},
+                    },
+                    "optional": True,
+                    "description": "Summed total of direct capital costs across all tables"
+                },
+            },
+            "<...> Indirect Capital Cost <...>": {
+                "Summed Total": {
+                    "Value": {
+                        "type": {int, float},
+                    },
+                    "optional": True,
+                    "description": "Summed total of indirect capital costs across all tables"
+                },
+            },
+            "<...> Other Non-Depreciable Capital Cost <...>": {
+                "Summed Total": {
+                    "Value": {
+                        "type": {int, float},
+                    },
+                    "optional": True,
+                    "description": "Summed total of other non-depreciable capital costs across all tables"
+                },
+            },
+        },
+    },
+}
+
 class Capital_Cost_Plugin:
 	'''
 

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -253,13 +253,14 @@ class Capital_Cost_Plugin:
 	def __init__(self, dcf, print_info):
 		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Capital_Cost_Plugin')
 		
-		# All the self.X variable are converted into Quantites just before their insertion, to avoid unnecessary complications
+		# Except for self.direct and self.indirect, which are natively Quantities as they are the results of sum_all_tables calls, 
+		# all the self.X variable are converted into Quantites just before their insertion, to avoid unnecessary complications
 		self.direct_capital_costs(dcf, print_info)  
-		self.direct_inflated = self.direct * dcf.combined_inflator
+		self.direct_inflated = self.direct.unit['USD'] * dcf.combined_inflator
 		
 		self.indirect_capital_costs(dcf, print_info)
-		self.indirect_inflated = self.indirect * dcf.combined_inflator
-		self.depreciable = self.direct + self.indirect
+		self.indirect_inflated = self.indirect.unit['USD'] * dcf.combined_inflator
+		self.depreciable = self.direct.unit['USD'] + self.indirect.unit['USD']
 		self.depreciable_inflated = self.direct_inflated + self.indirect_inflated
 		
 		self.non_depreciable_capital_costs(dcf, print_info)
@@ -268,9 +269,7 @@ class Capital_Cost_Plugin:
 		self.total_inflated = self.depreciable_inflated + self.non_depreciable_inflated
 
 		# convert the values into Quantities
-		self.direct = Quantity(self.direct, 'USD')
 		self.direct_inflated = Quantity(self.direct_inflated, 'USD')
-		self.indirect = Quantity(self.indirect, 'USD')
 		self.indirect_inflated = Quantity(self.indirect_inflated, 'USD')
 		self.depreciable = Quantity(self.depreciable, 'USD')
 		self.depreciable_inflated = Quantity(self.depreciable_inflated, 'USD')
@@ -285,13 +284,13 @@ class Capital_Cost_Plugin:
 		'''Calculation of direct capital costs by applying ``sum_all_tables()`` to "Direct Capital Cost" group.'''
                                                                
 		self.direct, self.direct_contributions = sum_all_tables(self.input_dict_resolved, 'Direct Capital Cost', 'Value', insert_total = True, 
-																class_object = dcf, print_info = print_info, return_contributions = True, unit = 'USD')
+																class_object = dcf, print_info = print_info, return_contributions = True)
 
 	def indirect_capital_costs(self, dcf, print_info):
 		'''Calculation of indirect capital costs by applying ``sum_all_tables()`` to "Indirect Capital Cost" group.'''
 
 		self.indirect = sum_all_tables(self.input_dict_resolved, 'Indirect Capital Cost', 'Value', insert_total = True, 
-									   class_object = dcf, print_info = print_info, unit = 'USD')
+									   class_object = dcf, print_info = print_info)
 
 	def non_depreciable_capital_costs(self, dcf, print_info):
 		'''Calculation of non-depreciable capital costs by calculating cost of land and applying
@@ -300,4 +299,4 @@ class Capital_Cost_Plugin:
 
 		non_depreciable = self.input_dict_resolved['Non-Depreciable Capital Costs']
 		self.non_depreciable = non_depreciable['Cost of land']['Value'].unit['USD/m2'] * non_depreciable['Land required']['Value'].unit['m2']
-		self.non_depreciable += sum_all_tables(self.input_dict_resolved, 'Other Non-Depreciable Capital Cost', 'Value', insert_total = True, class_object = dcf, print_info = print_info, unit = 'USD')
+		self.non_depreciable += sum_all_tables(self.input_dict_resolved, 'Other Non-Depreciable Capital Cost', 'Value', insert_total = True, class_object = dcf, print_info = print_info).unit['USD']

--- a/src/pyH2A/Plugins/Capital_Cost_Plugin.py
+++ b/src/pyH2A/Plugins/Capital_Cost_Plugin.py
@@ -250,18 +250,18 @@ class Capital_Cost_Plugin:
 	['Capital_Cost_Plugin'].direct_contributions : dict
 		Attribute containing cost contributions for "Direct Capital Cost" group.
 	'''
-		def __init__(self, dcf, print_info):
+	def __init__(self, dcf, print_info):
 		self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Capital_Cost_Plugin')
-        
+		
 		# All the self.X variable are converted into Quantites just before their insertion, to avoid unnecessary complications
 		self.direct_capital_costs(dcf, print_info)  
 		self.direct_inflated = self.direct * dcf.combined_inflator
-        
+		
 		self.indirect_capital_costs(dcf, print_info)
 		self.indirect_inflated = self.indirect * dcf.combined_inflator
 		self.depreciable = self.direct + self.indirect
 		self.depreciable_inflated = self.direct_inflated + self.indirect_inflated
-        
+		
 		self.non_depreciable_capital_costs(dcf, print_info)
 		self.non_depreciable_inflated = self.non_depreciable * dcf.ci_inflator
 		self.total = self.depreciable + self.non_depreciable
@@ -279,7 +279,7 @@ class Capital_Cost_Plugin:
 		self.total = Quantity(self.total, 'USD')
 		self.total_inflated = Quantity(self.total_inflated, 'USD')     
 
-		output_inserter_function(output_dict, self, dcf, 'Capital_Cost_Plugin')
+	output_inserter_function(output_dict, self, dcf, 'Capital_Cost_Plugin')
         
 	def direct_capital_costs(self, dcf, print_info):
 		'''Calculation of direct capital costs by applying ``sum_all_tables()`` to "Direct Capital Cost" group.'''

--- a/src/tests/plugins/capital_cost_plugin_test.py
+++ b/src/tests/plugins/capital_cost_plugin_test.py
@@ -1,5 +1,6 @@
 import pytest
 from pyH2A.Plugins.Capital_Cost_Plugin import Capital_Cost_Plugin
+from pyH2A.Utilities.Unit_Handler.quantity import Quantity
 
 
 class DummyDCF:
@@ -17,18 +18,35 @@ class DummyDCF:
     ):
 
         self.inp = {
-            "Dummy Left Direct Capital Cost Dummy Right": {
-                key: {"Value": value} for key, value in direct_costs.items()
+            "<...> Direct Capital Cost <...>": {
+                key: {
+                    "Value": value,
+                    "Unit": "USD"
+                } 
+                for key, value in direct_costs.items()
             },
-            "Dummy Left Indirect Capital Cost Dummy Right": {
-                key: {"Value": value} for key, value in indirect_costs.items()
+            "<...> Indirect Capital Cost <...>": {
+                key: {
+                    "Value": value,
+                    "Unit": "USD"
+                }
+                for key, value in indirect_costs.items()
             },
             "Non-Depreciable Capital Costs": {
-                "Cost of land ($ per acre)": {"Value": land_cost_per_acre},
-                "Land required (acres)": {"Value": land_required_acres},
+                "Cost of land": {
+                    "Value": land_cost_per_acre,
+                    "Unit": "USD/acre"
+                },
+                "Land required": {
+                    "Value": land_required_acres,
+                    "Unit": "acre"
+                },
             },  
             "Dummy Left Other Non-Depreciable Capital Cost Dummy Right": {
-                key: {"Value": value}
+                key: {
+                    "Value": value,
+                    "Unit": "USD"
+                }
                 for key, value in other_non_depreciable_costs.items()
             },
         }
@@ -61,12 +79,15 @@ class DummyDCF:
                 "ci_inflator": 1.05,
             },
             "expected": {
-                "direct": 9400000.0,
-                "indirect": 2000000.0,
-                "non_depreciable": 251000.0,
+                "direct": Quantity(9400000.0, "USD"),
+                "indirect": Quantity(2000000.0, "USD"),
+                "non_depreciable": Quantity(251000.0, "USD")
             },
         }
     ],
+    ids=[
+        "Realistic case - Capital Cost"
+    ]
 )
 def test_capital_cost_plugin(case):
     """Check plugin handles edge and real cases without errors and returns correct annualized costs."""
@@ -81,17 +102,17 @@ def test_capital_cost_plugin(case):
     # Tolerance (very small)
     tolerance = 1e-12
     
-    assert plugin.direct == pytest.approx(
-        expected["direct"],
+    assert plugin.direct.unit["USD"] == pytest.approx(
+        expected["direct"].unit["USD"],
         abs=tolerance
     )
     
-    assert plugin.indirect == pytest.approx(
-        expected["indirect"],
+    assert plugin.indirect.unit["USD"] == pytest.approx(
+        expected["indirect"].unit["USD"],
         abs=tolerance
     )
     
-    assert plugin.non_depreciable == pytest.approx(
-        expected["non_depreciable"],
+    assert plugin.non_depreciable.unit["USD"] == pytest.approx(
+        expected["non_depreciable"].unit["USD"],
         abs=tolerance
     )

--- a/src/tests/plugins/capital_cost_plugin_test.py
+++ b/src/tests/plugins/capital_cost_plugin_test.py
@@ -80,8 +80,15 @@ class DummyDCF:
             },
             "expected": {
                 "direct": Quantity(9400000.0, "USD"),
+                "direct_inflated": Quantity(10340000.0, "USD"),
                 "indirect": Quantity(2000000.0, "USD"),
-                "non_depreciable": Quantity(251000.0, "USD")
+                "indirect_inflated": Quantity(2200000.0, "USD"),
+                "depreciable": Quantity(11400000.0, "USD"),
+                "depreciable_inflated": Quantity(12540000.0, "USD"),
+                "non_depreciable": Quantity(251000.0, "USD"),
+                "non_depreciable_inflated": Quantity(263550.0, "USD"),
+                "total": Quantity(11651000.0, "USD"),
+                "total_inflated": Quantity(12803550.0, "USD")
             },
         }
     ],
@@ -89,6 +96,7 @@ class DummyDCF:
         "Realistic case - Capital Cost"
     ]
 )
+
 def test_capital_cost_plugin(case):
     """Check plugin handles edge and real cases without errors and returns correct annualized costs."""
 
@@ -106,13 +114,48 @@ def test_capital_cost_plugin(case):
         expected["direct"].unit["USD"],
         abs=tolerance
     )
-    
+
+    assert plugin.direct_inflated.unit["USD"] == pytest.approx(
+        expected["direct_inflated"].unit["USD"],
+        abs=tolerance
+    )
+
     assert plugin.indirect.unit["USD"] == pytest.approx(
         expected["indirect"].unit["USD"],
         abs=tolerance
     )
-    
+
+    assert plugin.indirect_inflated.unit["USD"] == pytest.approx(
+        expected["indirect_inflated"].unit["USD"],
+        abs=tolerance
+    )
+
+    assert plugin.depreciable.unit["USD"] == pytest.approx(
+        expected["depreciable"].unit["USD"],
+        abs=tolerance 
+    )
+
+    assert plugin.depreciable_inflated.unit["USD"] == pytest.approx(
+        expected["depreciable_inflated"].unit["USD"],
+        abs=tolerance
+    )
+
     assert plugin.non_depreciable.unit["USD"] == pytest.approx(
         expected["non_depreciable"].unit["USD"],
         abs=tolerance
     )
+
+    assert plugin.non_depreciable_inflated.unit["USD"] == pytest.approx(
+        expected["non_depreciable_inflated"].unit["USD"],
+        abs=tolerance
+    )   
+    
+    assert plugin.total.unit["USD"] == pytest.approx(
+        expected["total"].unit["USD"],
+        abs=tolerance
+    )  
+
+    assert plugin.total_inflated.unit["USD"] == pytest.approx(
+        expected["total_inflated"].unit["USD"],
+        abs=tolerance
+    )   


### PR DESCRIPTION
# Note
The plugin unit test runs fine locally with the new version of sum_all_tables, and will therefore work once we merge #60 and this one together, 
however, for end-to-end tests, **this one is blocked by issue #97** .

# Description

- Insert output_dict
- Adapt the code to use IO resolver
- update plugin test
- update docstrings


# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [x] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [x] Design / Architecture change


# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [x] Unit tests
- [ ] Integration tests
- [ ] Performance tests
- [ ] Manual tests / example model runs

## Test Details:
plugin test runs fine locally

# Checklist
- [x] Code follows pyH2A style guidelines
- [x] Self-review of code completed
- [x] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [x] No new warnings generated
- [x] Tests added / updated and passing
- [ ] Dependent changes merged and published
