### PR TITLE
Documentation for new users or non-python developers 

### DIFF
--- a/doc/Overview.rst
+++ b/doc/Overview.rst
@@ -1,3 +1,6 @@
+.. _Overview:
+
+
 Overview of pyH2A
 =================
 
@@ -6,9 +9,99 @@ Overview of pyH2A
    :local:
    :class: this-will-duplicate-information-and-it-is-still-useful-here   
 
+This page introduces the general logic of pyH2A, as well as its concrete implementation in the pyh2A code.
 
-1. General Principle
---------------------
+
+0. Navigating the pyH2A Codebase
+--------------------------------
+
+The pyH2A codebase is organized into a set of folders that separate the core calculation workflow, the :ref:`plugins`, and supporting functions for handling inputs / outputs / post-processing (referred to as "utilities").
+
+The main entry point of the code is located in:
+
+::
+
+   pyH2A/src/pyH2A/
+
+
+Overview of the folder structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- To understand how a calculation is executed, start with ``run_pyH2A.py`` and ``Discounted_Cash_Flow.py``.
+- To follow or modify the calculation steps, look at the files in the :ref:`plugins` folder.
+- To understand how input data is read and processed, refer to the ``Utilities`` folder.
+- To locate default parameters and the standard calculation structure, see ``Config/Defaults.md``.
+- To explore example inputs or test cases, consult the ``tests`` and ``Lookup_Tables`` folders.
+
+The structure below can be read as a map indicating where each of these elements is implemented.
+::
+
+   pyH2A/src/pyH2A/
+   │
+   ├── run_pyH2A.py
+   │   Entry point of the calculation:
+   │   - Initializes the model: calls methods to read and convert the input (.md) file into a dictionary
+   │   - Launches the workflow: runs the Discounted_Cash_Flow and puts the results in self.base_case
+   │
+   ├── Discounted_Cash_Flow.py
+   │   Core of the techno-economic calculation:
+   │   - Defines the pre_workflow, workflow and post_workflow (see section 2 below)
+   │
+   ├── LCA/
+   │   └── LCA.py
+   │       Life Cycle Analysis module:
+   │       - Contains the ``LCA`` class
+   │       - Called by ``Discounted_Cash_Flow`` to run the base case (single point calculation)
+   │
+   ├── Config/
+   │   └── Defaults.md
+   │       Default configuration:
+   │       - Defines the default plugin workflow (sections 3 and 4 below)
+   │       - Contains financial input values (section 2.1 below)
+   │
+   ├── Plugins/
+   │   Contains all ``*_Plugin`` files:
+   │   - Each plugin processes its necessary inputs (process_table call), performs calculations, and inserts the results in the dcf.inp dictionary 
+   │   - Plugins are executed sequentially in the workflow
+   │
+   ├── Utilities/
+   │   Functions for handling inputs and outputs:
+   │   - Conversion of input (.md) files into the dictionary structure
+   │   - Functions such as ``convert_input_to_dictionary``, ``process_table``, ``insert`` etc.
+   │
+   ├── Analysis/
+   │   Advanced analysis modules:
+   │   - Monte Carlo analysis
+   │   - Sensitivity analysis
+   │   - Not used in the base case calculation
+   │
+   └── Lookup_Tables/
+       Input data for example calculations:
+       - Contains files used as inputs in provided examples
+
+
+Additional test structure
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Files are available to test pyH2A execution.
+
+::
+
+   pyH2A/src/tests/
+   │
+   ├── end_to_end/
+   │   Input (.md) files for various complete hydrogen production pathways
+   │
+   ├── plugins/
+   │   Tests for individual plugin robustness
+   │
+   └── Utilities/
+       Tests for input/output processing:
+       - Verifies correct handling of dictionary entries and data resolution
+
+
+1. General Principle of pyH2A
+-----------------------------
 
 pyH2A performs a techno-economic analysis based on discounted cash flow methodology. Its purpose is to compute financial metrics such as annual cash flows and the levelized cost of hydrogen from a combination of technical assumptions and economic parameters.
 

--- a/doc/Overview.rst
+++ b/doc/Overview.rst
@@ -67,26 +67,29 @@ The structure below can be read as a map indicating where each of these elements
    │
    ├── Utilities/
    │   │
-   │   └── Input_Resolver/ 
+   │   └── IO/ 
    │   │   Modules for handling inputs and outputs
    │   │   └── input_resolver.py 
-   │   │   │   - Orchestrates the resolution of the inputs: retrieving values, conversion and sanity checks
-   │   │   │   - Contains the input_resolver_function and its related  
-   │   │   │   - Calls functions and methods from table_processor.py and unit_processor.py, which in turn call functions from the input_modification.py file (for example: ``process_table``)
+   │   │   │   - Orchestrates the resolution of the inputs: retrieving values, conversion into Quantity objects and sanity checks
+   │   │   │   - Contains the input_resolver_function and the related functions 
    │   │   │
-   │   │   └── check_functions.py 
-   │   │       - Functions performing sanity checks, called by the input resolver     
+   │   │   └── output_inserter.py 
+   │   │       - Orchestrates the resolution of the outputs: dimension and type checks, insertion in the dcf.inp dictionary
+   │   │       - Contains the output_inserter_function and the related functions 
    │   │
    │   └── Unit_Handler/ 
    │   │   └── quantity.py    
    │   │   │   - Modules for creating ``quantity`` objects, which associate a value to a unit
    │   │   └── config.py       
    │   │       - Contains the conversion factors between the base units (considered as the reference) and the units thta are supported in the input file
+   │   │   
+   │   └── check_functions.py 
+   │   │    - Functions performing sanity checks, called by the input resolver and by the output inserter
    │   │            
    │   └── input_modification.py 
    │   │   Functions for handling inputs and outputs, that is: to modify the dcf.inp dictionary :     
    │   │   - Conversion of input (.md) files into the dictionary structure
-   │   │   - Functions such as ``convert_input_to_dictionary``, ``process_table``, ``insert`` etc. 
+   │   │   - Functions such as ``convert_input_to_dictionary``, ``process_input``, ``insert``, ``sum_table``  etc. 
    │   │
    │   └── plugin_input_output_processing.py
    │   │   Serves to generate an input file template, based on a user-specified Workflow    
@@ -95,7 +98,7 @@ The structure below can be read as a map indicating where each of these elements
    │   │   Serves to define the final outputs format
    │   │
    │   └── find_nearest.py  
-   │       Used by some analysis modules 
+   │        - used in plugins (for example to identify the year index corresponding to a certain duration), and in some analysis modules   
    │
    ├── Analysis/
    │   Advanced analysis modules (not used in the base case calculation):
@@ -118,7 +121,7 @@ Files are available to test pyH2A execution.
 
 ::
 
-   pyH2A/src/tests/
+   pyH2A/src/
    │
    ├── end_to_end/
    │   Input (.md) files for various complete hydrogen production pathways
@@ -182,11 +185,13 @@ The calculation is organized as an ordered series of units referred to as :ref:`
 
 When a plugin is executed:
 
-- It reads the quantities it requires from the current dictionary. These quantities may originate from the input (.md) file or from previous plugins.
+- It reads the variables it requires from the current dictionary. These variables may originate from the input (.md) file or from previous plugins.
 
   .. admonition:: Code implementation
 
-     Within the plugin, the ``input_resolver_function`` call retrieves the actual value from the dictionary (``dcf.inp``) and applies conversions and checks. More detailed explanations about the dictionary structure and processing :ref:`are provided separately <dictionary-structure>`.
+     Within the plugin, the ``input_resolver_function`` call retrieves the actual value from the shared dictionary (``dcf.inp``), applies checks and creates the Quantity objects from the respective variables. 
+     The Quantity objects are stored in a local dictionary called ``self.input_dict_resolved``
+     More detailed explanations about the dictionary structure and processing :ref:`are provided separately <dictionary-structure>`.
 
 - It performs a defined set of calculations.
 
@@ -194,9 +199,10 @@ When a plugin is executed:
 
   .. admonition:: Code implementation
 
-     Within the plugin, the ``output_resolver`` method call inserts new variables, or updates existing ones, in the dictionary.
+     Within the plugin, the ``output_inserter_function`` method call inserts new variables, or updates existing ones, in the dcf.inp dictionary.
 
-The dictionary therefore represents the evolving economic model. At any stage, it contains all quantities defined up to that point, and a plugin can only rely on what is already present when it is executed. The execution order therefore defines the logical dependency structure of the model.
+The ``dcf.inp`` dictionary therefore represents the evolving economic model. At any stage, it contains all quantities defined up to that point, and a plugin can only rely on what is already present when it is executed. 
+The execution order therefore defines the logical dependency structure of the model.
 
 .. admonition:: Code implementation
 
@@ -222,12 +228,14 @@ The calculation sequence used in pyH2A is based on two categories of plugins:
 1. Default plugins, which define the common financial structure of the model.
 2. Scenario-specific plugins, which introduce calculations particular to a given hydrogen production pathway or study.
 
-The default plugins are specified in the ``Defaults.md`` file. They are always included in a calculation and provide the general discounted cash flow framework. This includes the construction of capital costs, operating costs, replacement costs, and the financial evaluation that leads to metrics such as annual cash flows and the levelized cost of hydrogen. 
+The default plugins are specified in the ``Defaults.md`` file. They are always included in a calculation and provide the general discounted cash flow framework. 
+This includes the construction of capital costs, operating costs, replacement costs, and the financial evaluation that leads to metrics such as annual cash flows and the levelized cost of hydrogen. 
 Note that the default Workflow (as defined in the ``Defaults.md`` file) also calls functions after each default plugin execution. These functions can be found as methods of the Discounted_Cash_Flow class.
 
 Scenario-specific plugins are specified in the user-defined input (.md) file. They typically introduce technical calculations (e.g., production performance, equipment sizing, technology-dependent costs) whose results enter the financial structure defined by the defaults.
 
-At runtime, pyH2A combines the predefined default plugins with the scenario-specific plugins into a single ordered sequence. The relative position of each plugin determines how technical quantities are incorporated into capital and operating costs, and how these costs ultimately influence the discounted cash flow results.
+At runtime, pyH2A combines the predefined default plugins with the scenario-specific plugins into a single ordered sequence. 
+The relative position of each plugin determines how technical quantities are incorporated into capital and operating costs, and how these costs ultimately influence the discounted cash flow results.
 
 Detailed guidance on plugin ordering is provided separately.
 
@@ -261,6 +269,7 @@ The default financial structure follows a defined economic progression:
 
      this is handled by the ``Fixed_Operating_Cost_Plugin`` and ``Variable_Operating_Cost_Plugin``.
 
-After these quantities have been established (production, capital costs, replacement costs, and operating costs) the discounted cash flow calculation is performed. Financial parameters such as discount rate, depreciation treatment, and taxation are applied to compute annual cash flows over the project lifetime. From these, net present value–based indicators, including the levelized cost of hydrogen, are derived.
+After these quantities have been established (production, capital costs, replacement costs, and operating costs) the discounted cash flow calculation is performed. 
+Financial parameters such as discount rate, depreciation treatment, and taxation are applied to compute annual cash flows over the project lifetime. From these, net present value–based indicators, including the levelized cost of hydrogen, are derived.
 
 The economic results therefore arise from a clearly structured sequence: production definition, cost construction, and financial evaluation, implemented through the default plugin sequence.

--- a/doc/Overview.rst
+++ b/doc/Overview.rst
@@ -29,7 +29,7 @@ Overview of the folder structure
 
 - To understand how a calculation is executed, start with ``run_pyH2A.py`` and ``Discounted_Cash_Flow.py``.
 - To follow or modify the calculation steps, look at the files in the :ref:`plugins` folder.
-- To understand how input data is read and processed, refer to the ``Utilities`` folder.
+- To understand how input and output data are read and processed, refer to the ``Utilities`` folder.
 - To locate default parameters and the standard calculation structure, see ``Config/Defaults.md``.
 - To explore example inputs or test cases, consult the ``tests`` and ``Lookup_Tables`` folders.
 
@@ -41,7 +41,8 @@ The structure below can be read as a map indicating where each of these elements
    ├── run_pyH2A.py
    │   Entry point of the calculation:
    │   - Initializes the model: calls methods to read and convert the input (.md) file into a dictionary
-   │   - Launches the workflow: runs the Discounted_Cash_Flow and puts the results in self.base_case
+   │   - Launches the base case (single point) calculation: calls Discounted_Cash_Flow and puts the results in self.base_case
+   │   - Launches the eventual meta workflow (Analysis modules)
    │
    ├── Discounted_Cash_Flow.py
    │   Core of the techno-economic calculation:
@@ -50,8 +51,8 @@ The structure below can be read as a map indicating where each of these elements
    ├── LCA/
    │   └── LCA.py
    │       Life Cycle Analysis module:
-   │       - Contains the ``LCA`` class
-   │       - Called by ``Discounted_Cash_Flow`` to run the base case (single point calculation)
+   │       - Contains the ``LCA`` class 
+   │       - Called by ``Discounted_Cash_Flow`` to run an LCA on a single point
    │
    ├── Config/
    │   └── Defaults.md
@@ -61,23 +62,53 @@ The structure below can be read as a map indicating where each of these elements
    │
    ├── Plugins/
    │   Contains all ``*_Plugin`` files:
-   │   - Each plugin processes its necessary inputs (process_table call), performs calculations, and inserts the results in the dcf.inp dictionary 
+   │   - Each plugin processes its necessary inputs (input_resolver_function call), performs calculations, and inserts the results (output_resolver call) in the dcf.inp dictionary (see part 2.2)
    │   - Plugins are executed sequentially in the workflow
    │
    ├── Utilities/
-   │   Functions for handling inputs and outputs:
-   │   - Conversion of input (.md) files into the dictionary structure
-   │   - Functions such as ``convert_input_to_dictionary``, ``process_table``, ``insert`` etc.
+   │   │
+   │   └── Input_Resolver/ 
+   │   │   Modules for handling inputs and outputs
+   │   │   └── input_resolver.py 
+   │   │   │   - Orchestrates the resolution of the inputs: retrieving values, conversion and sanity checks
+   │   │   │   - Contains the input_resolver_function and its related  
+   │   │   │   - Calls functions and methods from table_processor.py and unit_processor.py, which in turn call functions from the input_modification.py file (for example: ``process_table``)
+   │   │   │
+   │   │   └── check_functions.py 
+   │   │       - Functions performing sanity checks, called by the input resolver     
+   │   │
+   │   └── Unit_Handler/ 
+   │   │   └── quantity.py    
+   │   │   │   - Modules for creating ``quantity`` objects, which associate a value to a unit
+   │   │   └── config.py       
+   │   │       - Contains the conversion factors between the base units (considered as the reference) and the units thta are supported in the input file
+   │   │            
+   │   └── input_modification.py 
+   │   │   Functions for handling inputs and outputs, that is: to modify the dcf.inp dictionary :     
+   │   │   - Conversion of input (.md) files into the dictionary structure
+   │   │   - Functions such as ``convert_input_to_dictionary``, ``process_table``, ``insert`` etc. 
+   │   │
+   │   └── plugin_input_output_processing.py
+   │   │   Serves to generate an input file template, based on a user-specified Workflow    
+   │   │
+   │   └── output_utilities.py
+   │   │   Serves to define the final outputs format
+   │   │
+   │   └── find_nearest.py  
+   │       Used by some analysis modules 
    │
    ├── Analysis/
-   │   Advanced analysis modules:
-   │   - Monte Carlo analysis
-   │   - Sensitivity analysis
-   │   - Not used in the base case calculation
+   │   Advanced analysis modules (not used in the base case calculation):
+   │   - Monte Carlo analysis, Comparative Monte Carlo analysis
+   │   - Cost_Contributions_Analysis
+   │   - Sensitivity analysis 
+   │   - Optimization_Analysis
+   │   - Development_Distance_Time_Analysis
+   │   - Waterfall_Analysis
    │
    └── Lookup_Tables/
        Input data for example calculations:
-       - Contains files used as inputs in provided examples
+       - Contains files used as inputs in provided examples (for example: hourly irradiaiton data)
 
 
 Additional test structure
@@ -155,7 +186,7 @@ When a plugin is executed:
 
   .. admonition:: Code implementation
 
-     Within the plugin, the ``process_table`` method call retrieves the actual value from the dictionary (``dcf.inp``). More detailed explanations about the dictionary structure and processing :ref:`are provided separately <dictionary-structure>`.
+     Within the plugin, the ``input_resolver_function`` call retrieves the actual value from the dictionary (``dcf.inp``) and applies conversions and checks. More detailed explanations about the dictionary structure and processing :ref:`are provided separately <dictionary-structure>`.
 
 - It performs a defined set of calculations.
 
@@ -163,7 +194,7 @@ When a plugin is executed:
 
   .. admonition:: Code implementation
 
-     Within the plugin, the ``insert`` method call inserts new variables, or updates existing ones, in the dictionary.
+     Within the plugin, the ``output_resolver`` method call inserts new variables, or updates existing ones, in the dictionary.
 
 The dictionary therefore represents the evolving economic model. At any stage, it contains all quantities defined up to that point, and a plugin can only rely on what is already present when it is executed. The execution order therefore defines the logical dependency structure of the model.
 
@@ -179,7 +210,7 @@ The final financial quantities of interest (e.g. levelized cost of hydrogen) are
 
 .. admonition:: Code implementation
 
-   In ``Discounted_Cash_Flow`` class, this step is part of the ``post_workflow`` method call.
+   In the ``Discounted_Cash_Flow`` class, this step is part of the ``post_workflow`` method call.
 
 
 

--- a/doc/Overview.rst
+++ b/doc/Overview.rst
@@ -111,7 +111,7 @@ The structure below can be read as a map indicating where each of these elements
    │
    └── Lookup_Tables/
        Input data for example calculations:
-       - Contains files used as inputs in provided examples (for example: hourly irradiaiton data)
+       - Contains files used as inputs in provided examples (for example: hourly irradiation data)
 
 
 Additional test structure
@@ -246,15 +246,21 @@ Detailed guidance on plugin ordering is provided separately.
 4. Economic Logic Implemented by the Default Structure
 ------------------------------------------------------
 
-The default financial structure follows a defined economic progression:
-
-- Production definition: The production level is established or scaled to the target output, providing the reference for subsequent cost calculations.
+- Prior to the economic progression itself, quantities related to the plant lifetime (e.g. array ranging from 0 to the number of prodution years) and to the inflation (e.g. inflation correction between the reference year and the startup year) are generated.
 
   .. admonition:: Code implementation
 
-     this is handled by the ``Production_Scaling_Plugin``.
+     this is handled by the ``Time_Plugin`` followed by the ``Inflation_Plugin``.
 
-- Capital costs: The total investment required to construct the system at the specified production scale is calculated.
+The default financial structure then follows a defined economic progression:
+
+- Production definition: The production at gate is established as a function of the plant design production, providing the reference for subsequent cost calculations.
+
+  .. admonition:: Code implementation
+
+     this is handled by the ``Production_Plugin``.
+
+- Capital costs: The total investment required to construct the system at the specified design production is calculated.
 
   .. admonition:: Code implementation
 
@@ -270,9 +276,9 @@ The default financial structure follows a defined economic progression:
 
   .. admonition:: Code implementation
 
-     this is handled by the ``Fixed_Operating_Cost_Plugin`` and ``Variable_Operating_Cost_Plugin``.
+     this is handled by the ``Labor_Operating_Cost_Plugin``, ``Other_Fixed_Operating_Cost_Plugin`` and ``Variable_Operating_Cost_Plugin``.
 
 After these quantities have been established (production, capital costs, replacement costs, and operating costs) the discounted cash flow calculation is performed. 
-Financial parameters such as discount rate, depreciation treatment, and taxation are applied to compute annual cash flows over the project lifetime. From these, net present value–based indicators, including the levelized cost of product, are derived.
+Financial parameters such as discount rate, depreciation treatment, and taxation are applied to compute annual cash flows over the project lifetime. From these, net present value-based indicators, including the levelized cost of product, are derived.
 
 The economic results therefore arise from a clearly structured sequence: production definition, cost construction, and financial evaluation, implemented through the default plugin sequence.

--- a/doc/Overview.rst
+++ b/doc/Overview.rst
@@ -81,7 +81,7 @@ The structure below can be read as a map indicating where each of these elements
    │   │   └── quantity.py    
    │   │   │   - Modules for creating ``quantity`` objects, which associate a value to a unit
    │   │   └── config.py       
-   │   │       - Contains the conversion factors between the base units (considered as the reference) and the units thta are supported in the input file
+   │   │       - Contains the conversion factors between the base units (considered as the reference) and the units that are supported in the input file
    │   │   
    │   └── check_functions.py 
    │   │    - Functions performing sanity checks, called by the input resolver and by the output inserter
@@ -102,9 +102,9 @@ The structure below can be read as a map indicating where each of these elements
    │
    ├── Analysis/
    │   Advanced analysis modules (not used in the base case calculation):
-   │   - Monte Carlo analysis, Comparative Monte Carlo analysis
+   │   - Monte_Carlo analysis, Comparative_MC_analysis
    │   - Cost_Contributions_Analysis
-   │   - Sensitivity analysis 
+   │   - Sensitivity_Analysis 
    │   - Optimization_Analysis
    │   - Development_Distance_Time_Analysis
    │   - Waterfall_Analysis
@@ -121,10 +121,13 @@ Files are available to test pyH2A execution.
 
 ::
 
-   pyH2A/src/
+   pyH2A/
    │
+   ├── e2e_lcoh/
+   │   Executable test file for various complete hydrogen production pathways, checking if the calcualted levelized cost of hydrogen corresponds to the expected value
+   |
    ├── end_to_end/
-   │   Input (.md) files for various complete hydrogen production pathways
+   │   Input (.md) files for the e2e_lcoh/lcoh_test.py test 
    │
    ├── plugins/
    │   Tests for individual plugin robustness
@@ -137,7 +140,7 @@ Files are available to test pyH2A execution.
 1. General Principle of pyH2A
 -----------------------------
 
-pyH2A performs a techno-economic analysis based on discounted cash flow methodology. Its purpose is to compute financial metrics such as annual cash flows and the levelized cost of hydrogen from a combination of technical assumptions and economic parameters.
+pyH2A performs a techno-economic analysis based on discounted cash flow methodology. Its purpose is to compute financial metrics such as annual cash flows and the levelized cost of a deliverable (e.g. hydrogen) from a combination of technical assumptions and economic parameters.
 
 The model is not evaluated in a single global calculation. Instead, it is constructed progressively through a structured series of calculation stages. Each stage contributes technical, cost, or financial quantities that are required for the final discounted cash flow analysis.
 
@@ -212,7 +215,7 @@ The execution order therefore defines the logical dependency structure of the mo
 2.3. Final financial evaluation
 -------------------------------
 
-The final financial quantities of interest (e.g. levelized cost of hydrogen) are calculated.
+The final financial quantities of interest (e.g. levelized cost of product) are calculated.
 
 .. admonition:: Code implementation
 
@@ -226,10 +229,10 @@ The final financial quantities of interest (e.g. levelized cost of hydrogen) are
 The calculation sequence used in pyH2A is based on two categories of plugins:
 
 1. Default plugins, which define the common financial structure of the model.
-2. Scenario-specific plugins, which introduce calculations particular to a given hydrogen production pathway or study.
+2. Scenario-specific plugins, which introduce calculations particular to a given production pathway or study.
 
 The default plugins are specified in the ``Defaults.md`` file. They are always included in a calculation and provide the general discounted cash flow framework. 
-This includes the construction of capital costs, operating costs, replacement costs, and the financial evaluation that leads to metrics such as annual cash flows and the levelized cost of hydrogen. 
+This includes the construction of capital costs, operating costs, replacement costs, and the financial evaluation that leads to metrics such as annual cash flows and the levelized cost of the delivered product. 
 Note that the default Workflow (as defined in the ``Defaults.md`` file) also calls functions after each default plugin execution. These functions can be found as methods of the Discounted_Cash_Flow class.
 
 Scenario-specific plugins are specified in the user-defined input (.md) file. They typically introduce technical calculations (e.g., production performance, equipment sizing, technology-dependent costs) whose results enter the financial structure defined by the defaults.
@@ -245,7 +248,7 @@ Detailed guidance on plugin ordering is provided separately.
 
 The default financial structure follows a defined economic progression:
 
-- Production definition: The hydrogen production level is established or scaled to the target output, providing the reference for subsequent cost calculations.
+- Production definition: The production level is established or scaled to the target output, providing the reference for subsequent cost calculations.
 
   .. admonition:: Code implementation
 
@@ -263,13 +266,13 @@ The default financial structure follows a defined economic progression:
 
      this is handled by the ``Replacement_Plugin``.
 
-- Operating costs: Costs are separated into fixed and variable components. Fixed costs are independent of production level, while variable costs depend on hydrogen production.
+- Operating costs: Costs are separated into fixed and variable components. Fixed costs are independent of production level, while variable costs depend on the delivered production.
 
   .. admonition:: Code implementation
 
      this is handled by the ``Fixed_Operating_Cost_Plugin`` and ``Variable_Operating_Cost_Plugin``.
 
 After these quantities have been established (production, capital costs, replacement costs, and operating costs) the discounted cash flow calculation is performed. 
-Financial parameters such as discount rate, depreciation treatment, and taxation are applied to compute annual cash flows over the project lifetime. From these, net present value–based indicators, including the levelized cost of hydrogen, are derived.
+Financial parameters such as discount rate, depreciation treatment, and taxation are applied to compute annual cash flows over the project lifetime. From these, net present value–based indicators, including the levelized cost of product, are derived.
 
 The economic results therefore arise from a clearly structured sequence: production definition, cost construction, and financial evaluation, implemented through the default plugin sequence.

--- a/doc/Overview.rst
+++ b/doc/Overview.rst
@@ -81,7 +81,7 @@ The structure below can be read as a map indicating where each of these elements
 
 
 Additional test structure
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Files are available to test pyH2A execution.
 

--- a/doc/Overview.rst
+++ b/doc/Overview.rst
@@ -1,0 +1,142 @@
+Overview of pyH2A
+=================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :class: this-will-duplicate-information-and-it-is-still-useful-here   
+
+
+1. General Principle
+--------------------
+
+pyH2A performs a techno-economic analysis based on discounted cash flow methodology. Its purpose is to compute financial metrics such as annual cash flows and the levelized cost of hydrogen from a combination of technical assumptions and economic parameters.
+
+The model is not evaluated in a single global calculation. Instead, it is constructed progressively through a structured series of calculation stages. Each stage contributes technical, cost, or financial quantities that are required for the final discounted cash flow analysis.
+
+The economic results therefore emerge from the accumulation and interaction of all preceding calculations.
+
+
+2. Calculation Stages and Model State
+-------------------------------------
+
+Throughout execution, the variables of interest are read from, updated and added to a Python dictionary that serves as the “common thread” of the calculation.
+
+These variables include, for example:
+
+- Technical quantities (e.g., production rates, efficiencies, lifetimes)
+- Capital cost components
+- Operating costs (fixed and variable)
+- Financial parameters (e.g., discount rate, tax rate, depreciation schedules)
+- Intermediate and final financial results
+
+The use and calculation of these variables proceeds in the following order:
+
+
+2.1. Initialisation
+-------------------
+
+- User-specified input (.md) file is parsed and converted into a dictionary.
+
+  .. admonition:: Code implementation
+
+     In ``run_pyH2A`` and in ``Discounted_Cash_Flow`` classes, ``inp`` is the dictionary containing the variables of interest:
+
+     ``self.inp = convert_input_to_dictionary(self.input_file)``
+
+- Financial input values such as the reference year or the inflation factor are loaded from the ``Defaults.md`` file or computed.
+
+  .. admonition:: Code implementation
+
+     In ``Discounted_Cash_Flow`` class, this step is part of the ``pre_workflow`` method call.
+
+
+2.2. Plugin workflow
+--------------------
+
+The calculation is organized as an ordered series of units referred to as :ref:`plugins`.
+
+When a plugin is executed:
+
+- It reads the quantities it requires from the current dictionary. These quantities may originate from the input (.md) file or from previous plugins.
+
+  .. admonition:: Code implementation
+
+     Within the plugin, the ``process_table`` method call retrieves the actual value from the dictionary (``dcf.inp``). More detailed explanations about the dictionary structure and processing :ref:`are provided separately <dictionary-structure>`.
+
+- It performs a defined set of calculations.
+
+- It adds new variables to the dictionary or updates some of the existing ones.
+
+  .. admonition:: Code implementation
+
+     Within the plugin, the ``insert`` method call inserts new variables, or updates existing ones, in the dictionary.
+
+The dictionary therefore represents the evolving economic model. At any stage, it contains all quantities defined up to that point, and a plugin can only rely on what is already present when it is executed. The execution order therefore defines the logical dependency structure of the model.
+
+.. admonition:: Code implementation
+
+   The ordered execution of the plugins occurs in the ``workflow`` method inside the ``Discounted_Cash_Flow`` class.
+
+
+2.3. Final financial evaluation
+-------------------------------
+
+The final financial quantities of interest (e.g. levelized cost of hydrogen) are calculated.
+
+.. admonition:: Code implementation
+
+   In ``Discounted_Cash_Flow`` class, this step is part of the ``post_workflow`` method call.
+
+
+
+3. Default plugins and Scenario-specific plugins
+------------------------------------------------
+
+The calculation sequence used in pyH2A is based on two categories of plugins:
+
+1. Default plugins, which define the common financial structure of the model.
+2. Scenario-specific plugins, which introduce calculations particular to a given hydrogen production pathway or study.
+
+The default plugins are specified in the ``Defaults.md`` file. They are always included in a calculation and provide the general discounted cash flow framework. This includes the construction of capital costs, operating costs, replacement costs, and the financial evaluation that leads to metrics such as annual cash flows and the levelized cost of hydrogen. 
+Note that the default Workflow (as defined in the ``Defaults.md`` file) also calls functions after each default plugin execution. These functions can be found as methods of the Discounted_Cash_Flow class.
+
+Scenario-specific plugins are specified in the user-defined input (.md) file. They typically introduce technical calculations (e.g., production performance, equipment sizing, technology-dependent costs) whose results enter the financial structure defined by the defaults.
+
+At runtime, pyH2A combines the predefined default plugins with the scenario-specific plugins into a single ordered sequence. The relative position of each plugin determines how technical quantities are incorporated into capital and operating costs, and how these costs ultimately influence the discounted cash flow results.
+
+Detailed guidance on plugin ordering is provided separately.
+
+
+4. Economic Logic Implemented by the Default Structure
+------------------------------------------------------
+
+The default financial structure follows a defined economic progression:
+
+- Production definition: The hydrogen production level is established or scaled to the target output, providing the reference for subsequent cost calculations.
+
+  .. admonition:: Code implementation
+
+     this is handled by the ``Production_Scaling_Plugin``.
+
+- Capital costs: The total investment required to construct the system at the specified production scale is calculated.
+
+  .. admonition:: Code implementation
+
+     this is handled by the ``Capital_Cost_Plugin``.
+
+- Equipment replacement: The financial impact of component lifetimes shorter than the overall analysis period is incorporated.
+
+  .. admonition:: Code implementation
+
+     this is handled by the ``Replacement_Plugin``.
+
+- Operating costs: Costs are separated into fixed and variable components. Fixed costs are independent of production level, while variable costs depend on hydrogen production.
+
+  .. admonition:: Code implementation
+
+     this is handled by the ``Fixed_Operating_Cost_Plugin`` and ``Variable_Operating_Cost_Plugin``.
+
+After these quantities have been established (production, capital costs, replacement costs, and operating costs) the discounted cash flow calculation is performed. Financial parameters such as discount rate, depreciation treatment, and taxation are applied to compute annual cash flows over the project lifetime. From these, net present value–based indicators, including the levelized cost of hydrogen, are derived.
+
+The economic results therefore arise from a clearly structured sequence: production definition, cost construction, and financial evaluation, implemented through the default plugin sequence.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,8 @@ extensions = ['sphinx.ext.autodoc',
     		  'sphinx.ext.coverage',
     		  'sphinx.ext.viewcode',
     		  'numpydoc',
-    		  'autodocsumm'
+    		  'autodocsumm', 
+              'sphinx.ext.mathjax'
 ]
 
 autodoc_default_options = {

--- a/doc/dictionary_structure.rst
+++ b/doc/dictionary_structure.rst
@@ -1,0 +1,362 @@
+.. _dictionary-structure:
+
+
+Dictionary Structure and Data Flow
+==================================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :class: this-will-duplicate-information-and-it-is-still-useful-here
+   
+
+
+1. The Shared Calculation Dictionary
+------------------------------------
+
+All plugins operate on a shared Python dictionary that contains the variables used throughout the techno-economic calculation.  
+Within plugins, this dictionary is accessible as ``dcf.inp``.
+
+As the calculation progresses, this dictionary is continuously updated.  
+Plugins read values from it, perform calculations, and then insert new values or update existing ones.
+
+Because this dictionary is passed through the successive plugins, it represents the evolving state of the economic model.
+
+
+2. Structure of the Dictionary
+------------------------------
+
+The dictionary used in pyH2A has three levels of keys:
+
+.. code-block:: python
+
+   dcf.inp['top']['mid']['bottom']
+
+These three levels correspond conceptually to:
+
+- a **table name** (top key)
+- a **row name** (mid key)
+- a **column name** (bottom key)
+
+For example, the input file ``Thermal_base.md`` contains the table:
+
+::
+
+   # Technical Operating Parameters and Specifications
+
+   Name | Value
+   --- | ---
+   Operating Capacity Factor (%) | 90.0%
+   Plant Design Capacity (kg of H2/day) | 1,000
+
+After conversion into Python objects and processing the table, the value ``1000`` is stored as this dictionary keys' item:
+
+.. code-block:: python
+
+   dcf.inp['Technical Operating Parameters and Specifications']['Plant Design Capacity (kg of H2/day)']['Value']
+
+Conceptually, the dictionary structure can be visualized as follows:
+
+.. code-block:: text
+
+   dcf.inp
+   │
+   ├── "Technical Operating Parameters and Specifications"   ← table (top key)
+   │       │
+   │       ├── "Plant Design Capacity (kg of H2/day)"        ← row (mid key)
+   │       │        │
+   │       │        └── "Value" → 1000                        ← column (bottom key)
+   │       │
+   │       └── "Operating Capacity Factor (%)"
+   │                │
+   │                └── "Value" → 90.0
+   │
+   └── "Non-Depreciable Capital Costs"
+   │       │
+   │       └── "Land required (acres)"
+   │                │
+   │                └── "Value" → calculated by plugin
+   │				
+					
+					
+3. Dictionary Entries and the Concept of Tables
+-----------------------------------------------
+
+In pyH2A, many variables originate from tables written in the input ``.md`` files.  
+During initialization, these tables are converted into the internal dictionary structure. At this stage, the tables are only converted into Python objects; their entries are processed later when plugins request them (see Section 4).
+
+After this conversion, each entry of an input table corresponds to a position in the ``dcf.inp`` dictionary. In practice, the top-level key of the dictionary corresponds to the table name.
+
+However, the term *table* in pyH2A should be understood more generally than just the tables appearing in the input files.
+
+As the calculation progresses, plugins may create new entries or update existing ones using the same ``dcf.inp`` dictionary structure. These entries follow the same organization as those originating from the input tables.
+
+Consequently, a value stored in the dictionary may originate from two sources:
+
+1. **Tables defined in the input (.md) file**
+2. **Calculations or assignments performed by plugins**
+
+In this sense, a *table* refers to any group of entries stored under a given top-level key of the ``dcf.inp`` dictionary, regardless of whether it was originally defined in the input file or created later by a plugin.
+
+
+4. Conversion of Markdown Tables
+--------------------------------
+
+Tables written in the input ``.md`` files are converted into the Python dictionary structure by the function ``convert_input_to_dictionary``.
+
+This function is called in both the ``pyH2A`` class and the ``Discounted_Cash_Flow`` class before the plugin workflow is executed.
+
+It is important to note that this step **does not evaluate the entries** in the tables.  
+It only converts their structure into Python objects so that they can later be processed by plugins when needed.
+
+
+5. Processing inputs: the ``process_table`` method
+--------------------------------------------------
+
+When a plugin requires input data, it retrieves it from the dictionary using the ``process_table`` method.
+
+Each plugin typically begins by calling ``process_table`` for the entries it needs.  
+This call retrieves the actual value corresponding to the requested dictionary position.
+
+For example:
+
+.. code-block:: python
+
+   process_table(dcf.inp, 'Solar Concentrator', 'Value')
+   
+
+One important feature of pyH2A is that table entries in the input file do not necessarily contain numerical values.  
+They can instead refer to other variables or paths.
+
+For example, in ``PV_E_Base.md`` : 
+
+::
+
+	# Irradiance Area Parameters
+
+	Name | Value | Comment
+	--- | --- | ---
+	Module Tilt (degrees) | Hourly Irradiation > Latitude > Value | Module tilt equal to latitude of location.
+
+Here the entry points to another variable in the dictionary.
+
+When Hourly_Irradiation_Plugin executes ``process_table(dcf.inp, 'Hourly Irradiation', 'Value')``, the corresponding entry ``dcf.inp['Irradiance Area Parameters']['Module Tilt (degrees)']['Value']`` ultimately receives the value stored at: 
+
+.. code-block:: python
+
+   dcf.inp[Hourly Irradiation']['Latitude']['Value']
+   
+In the present example, it means that the value of the module tilt is simply made equal to the latitude.
+
+
+6. Value Processing and Path-Based Multiplication
+-------------------------------------------------
+
+In many cases, the numerical value appearing in a table is not the final value used in the calculation.  
+pyH2A allows entries to be expressed as a **base value multiplied by another variable** stored elsewhere in the dictionary.
+
+This is done using the optional ``Path`` column in input tables.
+
+For example, in ``PEC_Base.md``:
+
+::
+
+   # Direct Capital Costs - Water Management
+
+   Name | Value | Path | Comment
+   --- | --- | --- | ---
+   Water pump ($) | 213.0 | None | Based on Pinaud 2013.
+   Water Manifold Piping ($ per cell) | 11.58 | PEC Cells > Number > Value |
+
+The entry indicates that the cost of water manifold piping is **11.58 $ per cell**.  
+The total cost therefore depends on the number of PEC cells defined elsewhere in the model.
+
+When the table is processed, pyH2A retrieves the referenced value:
+
+::
+
+   dcf.inp['PEC Cells']['Number']['Value']
+
+and multiplies it by the base value specified in the table:
+
+::
+
+   total_cost = 11.58 * dcf.inp['PEC Cells']['Number']['Value']
+
+This multiplication is performed automatically when the table entry is processed.
+
+  .. admonition:: Code implementation
+
+     The multiplication is handled by the ``process_input()`` method, which is called internally by ``process_table()``. If a ``Path`` column exists, the value retrieved from that path is multiplied with the entry in the ``Value`` column, and the resulting number replaces the original value in the dictionary.
+
+
+7. Flexible Rows and Table Groups
+---------------------------------
+
+Some plugins interpret tables in a way that allows the user to define multiple entries without fixing their exact row structure. Two mechanisms are used for this: **flexible rows** and **table groups**.
+
+
+Flexible rows
+~~~~~~~~~~~~~
+
+In some tables, the specific row names do not affect the calculation.  
+The rows are simply used to list multiple contributions that will later be combined.
+
+For example, in the ``Variable_Operating_Cost_Plugin`` the method ``other_variable_costs`` computes the sum of all entries in the table ``Other Variable Operating Cost``:
+
+.. code-block:: python
+
+   self.other = dcf.chemical_inflator * sum_all_tables(dcf.inp,'Other Variable Operating Cost','Value',
+       insert_total = True, class_object = dcf, print_info = print_info
+   )
+
+In this case, the individual row names inside the table do not influence the calculation.  
+The user may therefore define any number of rows describing different cost components. Their values are simply summed when the plugin processes the table.
+
+
+Table groups
+~~~~~~~~~~~~
+
+In some situations, several tables that share a common theme are grouped together based on their names.
+
+A plugin may search for all tables whose top-level key contains a given string and treat them as belonging to the same group.
+
+For example, in ``Fixed_Operating_Cost_Plugin`` the method ``other_cost`` performs the calculation:
+
+.. code-block:: python
+
+   self.other = sum_all_tables(dcf.inp, 'Other Fixed Operating Cost', 'Value',
+       insert_total = True, class_object = dcf, print_info = print_info
+   ) * dcf.combined_inflator
+
+Here, every table whose name contains the string ``Other Fixed Operating Cost`` is included in the calculation.
+
+This allows users to define several tables such as:
+
+- ``Plant A Other Fixed Operating Cost``
+- ``Water Treatment Other Fixed Operating Cost``
+- ``Utilities Other Fixed Operating Cost``
+
+Each table can contain its own entries, but all their values are combined when the plugin computes the total cost.
+
+
+Purpose of These Mechanisms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Flexible rows and table groups provide a way to structure input files in a clear and modular way.
+
+Users can separate different cost contributions into individual rows or tables for readability, while the plugin logic automatically aggregates them during the calculation.
+
+8. Inserting or Updating Values: the ``insert`` method
+------------------------------------------------------
+
+After performing calculations, plugins store their results in the dictionary using the ``insert`` method.
+
+This method can either:
+
+- create a **new dictionary entry**, or
+- **update the value** of an existing entry.
+
+Example: in ``Solar_Concentrator_Plugin``
+
+- creating a new entry:
+
+The variable ``total_land_area_acres`` is calculated and inserted with:
+
+.. code-block:: python
+
+   insert(
+       dcf,
+       'Non-Depreciable Capital Costs', 'Land required (acres)', 'Value',
+       self.total_land_area_acres,
+       __name__,print_info = print_info
+   )
+
+This creates the dictionary entry:
+
+.. code-block:: python
+
+   dcf.inp['Non-Depreciable Capital Costs']['Land required (acres)']['Value']
+
+
+- updating an existing entry.
+
+The plugin reads the existing values of the ``Non-Depreciable Capital Costs`` table, including the existing value of the ``Solar Collection Area (m2)`` row:
+
+.. code-block:: python
+
+   process_table(dcf.inp, 'Non-Depreciable Capital Costs', 'Value')
+
+
+A new value ``total_solar_collection_area_m2`` is calculated, and its value is assigned to ``dcf.inp['Non-Depreciable Capital Costs']['Solar Collection Area (m2)']['Value']``:
+
+.. code-block:: python
+
+   insert(
+       dcf,
+       'Non-Depreciable Capital Costs', 'Solar Collection Area (m2)','Value',
+       self.total_solar_collection_area_m2,
+       __name__,print_info = print_info
+   )
+
+In other words, this operation updates:
+
+.. code-block:: python
+
+   dcf.inp['Non-Depreciable Capital Costs']['Solar Collection Area (m2)']['Value']
+
+
+9. Dependency Between Plugins
+-----------------------------
+
+When a plugin requests a value from the dictionary using ``process_table``, the corresponding entry must already exist.
+
+This entry must therefore have been:
+
+- defined in the input ``.md`` file, or
+- inserted earlier by another plugin.
+
+For this reason, the **execution order of plugins determines the dependency structure of the model**.  
+A plugin can only rely on variables that have already been defined earlier in the workflow.
+
+The data flow can be represented schematically as:
+
+.. code-block:: text
+
+        Input tables (.md)
+                │
+                ▼
+        convert_input_to_dictionary
+                │
+                ▼
+            dcf.inp
+      (shared calculation dictionary)
+                │
+                ▼
+        ┌──────────────────┐
+        │     Plugin 1     │
+        │  - process_table │
+        │  - calculations  │
+        │  - insert        │
+        └──────────────────┘
+                │
+                ▼
+            dcf.inp
+       (with newly inserted variables)
+                │
+                ▼
+        ┌──────────────────┐
+        │     Plugin 2     │
+        │  - process_table │
+        │  - calculations  │
+        │  - insert        │
+        └──────────────────┘
+                │
+                ▼
+            dcf.inp
+                │
+                ▼
+               ...
+                │
+                ▼
+        Final financial evaluation

--- a/doc/dictionary_structure.rst
+++ b/doc/dictionary_structure.rst
@@ -133,7 +133,7 @@ For example, in ``Hourly_Irradiation_Plugin``, the ``input_dict`` contains, amon
 				"bounds": (250, 500),
 			},
 			"Unit": {
-				"dimension": "temperature",
+				"dimension": "absolute_temperature",
 			},
 			"optional": False,
 			"description": "Nominal operating temperature of irradiated module."
@@ -155,7 +155,7 @@ This call retrieves the items corresponding to the dictionary positions found in
 In our example: 
  1. ``dcf.inp['Irradiance Area Parameters']['Nominal operating temperature']['Value']`` is retrieved. 
  2. A Quantity object is created from the Value and the related Unit (``dcf.inp['Irradiance Area Parameters']['Nominal operating temperature']['Unit']``). This step is bypassed if the Value is already a Quantity object.
- 3. The input resolver checks if the unit of measurement is consistent with the expected dimension as per the input_dict (in the present case: temperature). If this is not the case, an error message is thrown.
+ 3. The input resolver checks if the unit of measurement is consistent with the expected dimension as per the input_dict (in the present case: absolute_temperature). If this is not the case, an error message is thrown.
  4. The input resolver checks if the value expressed in the Base unit (generally: SI unit) respects the ``bounds`` specified in input_dict. An operating temperature below 250 K or above 500 K would be unrealistic, and would therefore lead to an error message.
  5. The Quantity object is added to the local ``self.input_dict_resolved`` dictionary. The quantities present in this dictionary are the ones used within the plugin for all the calculations.
  
@@ -167,24 +167,16 @@ For example, in ``PV_E_Base.md`` :
 
 ::
 
-	# Irradiance Area Parameters
+   # Irradiation Used
 
-	Name | Value | Unit | Comment
-	--- | --- | ---
-	Module Tilt | Hourly Irradiation > Latitude > Value | deg | Module tilt equal to latitude of location.
+   Name | Value | Comment
+   --- | --- | --- 
+   Data | Hourly Irradiation > Horizontal Single Axis Tracking > Value | Single axis tracking based on Chang 2020.
 
 Here the entry points to another variable in the dictionary.
 
-When Hourly_Irradiation_Plugin executes ``input_resolver_function``, the ``dcf.inp['Irradiance Area Parameters']['Module Tilt']['Value']`` entry ultimately receives the value stored at: 
-
-.. code-block:: python
-
-   dcf.inp[Hourly Irradiation']['Latitude']['Value']
+When Hourly_Irradiation_Plugin executes ``input_resolver_function``, the ``dcf.inp['Irradiation Used']['Data']['Value']`` entry ultimately receives the value stored at ``dcf.inp['Hourly Irradiation']['Horizontal Single Axis Tracking']['Value']``. 
    
-In the present example, it means that the value of the module tilt is simply made equal to the latitude.
-
-
-
 
 6. Value Processing and Path-Based Multiplication
 -------------------------------------------------
@@ -203,7 +195,7 @@ For example, in ``PEC_Base.md``:
    Name | Value | Path | Unit | Comment
    --- | --- | --- | ---
    Water pump | 213.0 | None | USD | Based on Pinaud 2013.
-   Water Manifold Piping | 11.58 | USD | PEC Cells > Number > Value |
+   Water Manifold Piping | 11.58 | PEC Cells > Number > Value | USD |
 
 The entry indicates that the cost of water manifold piping is **11.58 $ per cell**.  
 The total cost therefore depends on the number of PEC cells defined elsewhere in the model.
@@ -220,7 +212,7 @@ and multiplies it by the base value specified in the table:
 
    total_cost = 11.58 * dcf.inp['PEC Cells']['Number']['Value']
 
-This multiplication is performed automatically when the table entry is processed.
+This multiplication is performed automatically when the table entry is processed. Note that the ``Unit`` (USD in this example) applies to the ``Value * Path``.
 
   .. admonition:: Code implementation
 
@@ -239,13 +231,12 @@ Flexible rows
 In some tables, the specific row names do not affect the calculation.  
 The rows are simply used to list multiple contributions that will later be combined.
 
-For example, in the ``Variable_Operating_Cost_Plugin`` the method ``other_variable_costs`` computes the sum of all entries in the table ``Other Variable Operating Cost``:
+For example, in the ``Variable_Operating_Cost_Plugin`` the ``other_variable_costs`` method computes the sum of all entries in the table ``Other Variable Operating Cost``:
 
 .. code-block:: python
 
-   self.other = dcf.chemical_inflator * sum_all_tables(dcf.inp,'Other Variable Operating Cost','Value',
-       insert_total = True, class_object = dcf, print_info = print_info, unit = 'USD'
-   )
+   self.other = dcf.chemical_inflator * sum_all_tables(self.input_dict_resolved,'Other Variable Operating Cost','Value',
+       insert_total = True, class_object = dcf, print_info = print_info).unit['USD']
 
 In this case, the individual row names inside the table do not influence the calculation.  
 The user may therefore define any number of rows describing different cost components. Their values are simply summed when the plugin processes the table.
@@ -262,17 +253,15 @@ For example, in ``Fixed_Operating_Cost_Plugin`` the method ``other_cost`` perfor
 
 .. code-block:: python
 
-   self.other = sum_all_tables(dcf.inp, 'Other Fixed Operating Cost', 'Value',
-       insert_total = True, class_object = dcf, print_info = print_info, unit = 'USD'
-   ) * dcf.combined_inflator
+   self.other = sum_all_tables(self.input_dict_resolved, 'Other Fixed Operating Cost', 'Value',
+       insert_total = True, class_object = dcf, print_info = print_info).unit['USD'] * dcf.combined_inflator
 
 Here, every table whose name contains the string ``Other Fixed Operating Cost`` is included in the calculation.
 
 This allows users to define several tables such as:
 
 - ``Plant A Other Fixed Operating Cost``
-- ``Water Treatment Other Fixed Operating Cost``
-- ``Utilities Other Fixed Operating Cost``
+- ``Water Treatment Other Fixed Operating Cost downstream``
 
 Each table can contain its own entries, but all their values are combined when the plugin computes the total cost.
 
@@ -375,40 +364,40 @@ The data flow can be represented schematically as:
 
 .. code-block:: text
 
-        Input tables (.md)
-                │
-                ▼
-        convert_input_to_dictionary
-                │
-                ▼
-            dcf.inp
-      (shared calculation dictionary)
-                │
-                ▼
+               Input tables (.md)
+                       │
+                       ▼
+          convert_input_to_dictionary
+                       │
+                       ▼
+                    dcf.inp
+        (shared calculation dictionary)
+                       │
+                       ▼                    
         ┌────────────────────────────┐
         │         Plugin 1           │
         │ - input_resolver_function  │
         │ - calculations             │
-        │ - output_resolver          │
+        │ - output_inserter_function │
         └────────────────────────────┘
-                │
-                ▼
-            dcf.inp
-       (with newly inserted variables)
-                │
-                ▼
+                       │
+                       ▼
+                   dcf.inp
+        (with newly inserted variables)
+                       │
+                       ▼
         ┌────────────────────────────┐
         │         Plugin 2           │
         │ - input_resolver_function  │
         │ - calculations             │
-        │ - output_resolver          │
+        │ - output_inserter_function │
         └────────────────────────────┘
-                │
-                ▼
-            dcf.inp
-                │
-                ▼
-               ...
-                │
-                ▼
-        Final financial evaluation
+                       │
+                       ▼
+                   dcf.inp
+                       │
+                       ▼
+                      ...
+                       │
+                       ▼
+          Final financial evaluation

--- a/doc/dictionary_structure.rst
+++ b/doc/dictionary_structure.rst
@@ -46,15 +46,15 @@ For example, the input file ``Thermal_base.md`` contains the table:
 
    Name | Value | Unit
    --- | --- | ---
-   Operating Capacity Factor | 90.0% | -
-   Plant Design Capacity | 1,000 | kg/day
+   Operating capacity factor | 90.0% | -
+   Plant design capacity | 1,000 | kg/day
 
 After conversion into Python objects and processing the table, the value ``1000``  and the associated unit ``kg/day`` are stored as this dictionary keys' item:
 
 .. code-block:: python
 
-   dcf.inp['Technical Operating Parameters and Specifications']['Plant Design Capacity']['Value']
-   dcf.inp['Technical Operating Parameters and Specifications']['Plant Design Capacity']['Unit']
+   dcf.inp['Technical Operating Parameters and Specifications']['Plant design capacity']['Value']
+   dcf.inp['Technical Operating Parameters and Specifications']['Plant design capacity']['Unit']
 
 Conceptually, the dictionary structure can be visualized as follows:
 
@@ -64,12 +64,12 @@ Conceptually, the dictionary structure can be visualized as follows:
    │
    ├── "Technical Operating Parameters and Specifications"   ← table (top key)
    │       │
-   │       ├── "Plant Design Capacity"        ← row (mid key)
+   │       ├── "Plant design capacity"        ← row (mid key)
    │       │        │
    │       │        └── "Value" → 1000        ← column (bottom key)
    │       │        └── "Unit" → 'kg/day'       ← column (bottom key)   
    │       │
-   │       └── "Operating Capacity Factor"
+   │       └── "Operating capacity factor"
    │                │
    │                └── "Value" → 0.9
    │                └── "Unit" → '-'   
@@ -127,7 +127,7 @@ For example, in ``Hourly_Irradiation_Plugin``, the ``input_dict`` contains, amon
 .. code-block:: python
 
    "Irradiance Area Parameters": {	
-      <...>,   
+   
       "Nominal operating temperature": {
          "Value": {
             "type": {float,},
@@ -139,7 +139,7 @@ For example, in ``Hourly_Irradiation_Plugin``, the ``input_dict`` contains, amon
          "optional": False,
          "description": "Nominal operating temperature of irradiated module."
       },   
-      <...>,    
+ 
    }
 
 which means that ``Hourly_Irradiation__Plugin`` uses, among others, the value of ``dcf.inp['Irradiance Area Parameters']['Nominal operating temperature']['Value']`` as an input.
@@ -162,7 +162,7 @@ In our example:
  
 
 One important feature of pyH2A is that table entries in the input file do not necessarily contain numerical values.  
-They can instead refer to other variables or paths.
+They can instead refer to other variables or paths. When this is the case, the unit in which the variable should be picked up must be specified. 
 
 For example, in ``PV_E_Base.md`` : 
 
@@ -170,13 +170,13 @@ For example, in ``PV_E_Base.md`` :
 
    # Irradiation Used
 
-   Name | Value | Comment
-   --- | --- | --- 
-   Data | Hourly Irradiation > Horizontal Single Axis Tracking > Value | Single axis tracking based on Chang 2020.
+   Name | Value | Unit | Comment |
+   --- | --- | --- | --- |
+   Data | {Hourly Irradiation > Horizontal single axis tracking > Value, kWh/m2} | kWh/m2 | Single axis tracking based on Chang 2020. |
 
 Here the entry points to another variable in the dictionary.
 
-When Hourly_Irradiation_Plugin executes ``input_resolver_function``, the ``dcf.inp['Irradiation Used']['Data']['Value']`` entry ultimately receives the value stored at ``dcf.inp['Hourly Irradiation']['Horizontal Single Axis Tracking']['Value']``. 
+When Hourly_Irradiation_Plugin executes ``input_resolver_function``, the ``dcf.inp['Irradiation Used']['Data']['Value']`` entry ultimately receives the value stored at ``dcf.inp['Hourly Irradiation']['Horizontal Single Axis Tracking']['Value'].unit['kWh/m2']`` expressed in turn in kWh/m2 (as per the ``Unit`` column). 
    
 
 6. Value Processing and Path-Based Multiplication
@@ -196,7 +196,7 @@ For example, in ``PEC_Base.md``:
    Name | Value | Path | Unit | Comment
    --- | --- | --- | ---
    Water pump | 213.0 | None | USD | Based on Pinaud 2013.
-   Water Manifold Piping | 11.58 | PEC Cells > Number > Value | USD |
+   Water Manifold Piping | 11.58 | {PEC Cells > Number > Value, -} | USD |
 
 The entry indicates that the cost of water manifold piping is **11.58 $ per cell**.  
 The total cost therefore depends on the number of PEC cells defined elsewhere in the model.
@@ -211,9 +211,9 @@ and multiplies it by the base value specified in the table:
 
 ::
 
-   total_cost = 11.58 * dcf.inp['PEC Cells']['Number']['Value']
+   total_cost = 11.58 * dcf.inp['PEC Cells']['Number']['Value'].unit['-']
 
-This multiplication is performed automatically when the table entry is processed. Note that the ``Unit`` (USD in this example) applies to the ``Value * Path``.
+This multiplication is performed automatically when the table entry is processed. Note that the table ``Unit`` (USD in this example) applies to the ``Value * Path``.
 
   .. admonition:: Code implementation
 
@@ -232,15 +232,33 @@ Flexible rows
 In some tables, the specific row names do not affect the calculation.  
 The rows are simply used to list multiple contributions that will later be combined.
 
-For example, in the ``Variable_Operating_Cost_Plugin`` the ``other_variable_costs`` method computes the sum of all entries in the table ``Other Variable Operating Cost``:
+For example, in ``Variable_Operating_Cost_Plugin``, the ``input_dict`` structure contains:
 
 .. code-block:: python
 
-   self.other = dcf.chemical_inflator * sum_all_tables(self.input_dict_resolved,'Other Variable Operating Cost','Value',
-       insert_total = True, class_object = dcf, print_info = print_info).unit['USD']
+   ...
+	"Utilities": {
+		"<...>": {
+			"Cost_Value": {
+				"type": {int, float, str, np.ndarray},
+				"bounds": (0, None),
+				"path": "Cost_Path"
+			},
+			"Cost_Unit": {
+				"dimension": "currency" # we omit the basis on purpose, at it is transparent, and will simplify with the basis per kg; the raito is precisely what the conversion factor is there for
+			},		
+   ...
 
-In this case, the individual row names inside the table do not influence the calculation.  
-The user may therefore define any number of rows describing different cost components. Their values are simply summed when the plugin processes the table.
+The wildcard pattern (``<...>``) indicates to the ``input_resolver_function`` that all the middle keys of the Utilities table must be processed.
+The user may therefore define any number of rows describing different cost components.
+
+The calculation can then be performed, iterating on all the rows (middle keys) of the ``Utilities`` table:
+
+.. code-block:: python
+
+		for key in self.input_dict_resolved['Utilities']:
+			utility = Utility(self.input_dict_resolved['Utilities'][key], dcf)
+			self.utilities += utility.cost_per_unit_of_product.unit['USD/kg']
 
 
 Table groups
@@ -250,22 +268,67 @@ In some situations, several tables that share a common theme are grouped togethe
 
 A plugin may search for all tables whose top-level key contains a given string and treat them as belonging to the same group.
 
-For example, in ``Fixed_Operating_Cost_Plugin`` the method ``other_cost`` performs the calculation:
+For example, in ``Variable_Operating_Cost_Plugin``,  the ``input_dict`` structure contains:
 
 .. code-block:: python
 
-   self.other = sum_all_tables(self.input_dict_resolved, 'Other Fixed Operating Cost', 'Value',
-       insert_total = True, class_object = dcf, print_info = print_info).unit['USD'] * dcf.combined_inflator
+   ...
+	"<...> Other Variable Operating Cost <...>": {
+		"<...>": {
+			"Value": {
+				"type": {int, float, np.ndarray},
+				"bounds": (0, None)
+			},
+			"Unit": {
+				"dimension": "currency"
+			},
+			"optional": True,
+			"description": "Value for variable operating cost. `sum_all_tables()` is used for summing all tables in this group."
+		},
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed total',
+                'middle_key_total_group_insertion': 'Summed group total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },			
+	}
 
-Here, every table whose name contains the string ``Other Fixed Operating Cost`` is included in the calculation.
+
+Here, every table whose name contains the string ``Other Variable Operating Cost`` is included in the calculation.
 
 This allows users to define several tables such as:
 
-- ``Plant A Other Fixed Operating Cost``
-- ``Water Treatment Other Fixed Operating Cost downstream``
+- ``Plant A Other Variable Operating Cost``
+- ``Water Treatment Other Variable Operating Cost downstream``
 
-Each table can contain its own entries, but all their values are combined when the plugin computes the total cost.
+The presence of the ``sum_tables`` middle key indicates to the ``input_resolver_function`` that the following operations must be performed:
 
+- Within each table, sum the Values of all the rows and insert the result in the ``Summed total`` middle key.
+- The respective Summed totals of the tables belonging to the group are summed in turn, and the result is  inserted in the ``Summed group total`` middle key
+
+  .. admonition:: Example
+
+   If the input dictionary contains 
+
+   ``Plant A Other Variable Operating Cost > Electricty > Value`` equal to 1 USD
+
+   ``Plant A Other Variable Operating Cost > Water > Value`` equal to 2 USD
+
+   ``Water Treatment Other Variable Operating Cost downstream > Electricty > Value`` equal to 10 USD
+
+
+   The input_resolver_function all will create:
+
+   ``Plant A Other Variable Operating Cost > Summed total > Value`` equal to 3 USD
+
+   ``Water Treatment Other Variable Operating Cost downstream > Summed total > Value`` equal to 10 USD
+
+   ``Other Variable Operating Cost > Summed group total > Value`` equal to 13 USD
+   
 
 Purpose of These Mechanisms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -273,6 +336,7 @@ Purpose of These Mechanisms
 Flexible rows and table groups enable to structure input files in a clear and modular way.
 
 Users can separate different cost contributions into individual rows or tables for readability, while the plugin logic automatically aggregates them during the calculation.
+
 
 8. Inserting or Updating Values: ``output_inserter_function``
 -------------------------------------------------------------

--- a/doc/dictionary_structure.rst
+++ b/doc/dictionary_structure.rst
@@ -44,16 +44,17 @@ For example, the input file ``Thermal_base.md`` contains the table:
 
    # Technical Operating Parameters and Specifications
 
-   Name | Value
-   --- | ---
-   Operating Capacity Factor (%) | 90.0%
-   Plant Design Capacity (kg of H2/day) | 1,000
+   Name | Value | Unit
+   --- | --- | ---
+   Operating Capacity Factor | 90.0 | %
+   Plant Design Capacity | 1,000 | kg/day
 
-After conversion into Python objects and processing the table, the value ``1000`` is stored as this dictionary keys' item:
+After conversion into Python objects and processing the table, the value ``1000``  and the associated unit ``kg/day`` are stored as this dictionary keys' item:
 
 .. code-block:: python
 
-   dcf.inp['Technical Operating Parameters and Specifications']['Plant Design Capacity (kg of H2/day)']['Value']
+   dcf.inp['Technical Operating Parameters and Specifications']['Plant Design Capacity']['Value']
+   dcf.inp['Technical Operating Parameters and Specifications']['Plant Design Capacity']['Unit']
 
 Conceptually, the dictionary structure can be visualized as follows:
 
@@ -63,19 +64,21 @@ Conceptually, the dictionary structure can be visualized as follows:
    │
    ├── "Technical Operating Parameters and Specifications"   ← table (top key)
    │       │
-   │       ├── "Plant Design Capacity (kg of H2/day)"        ← row (mid key)
+   │       ├── "Plant Design Capacity"        ← row (mid key)
    │       │        │
-   │       │        └── "Value" → 1000                        ← column (bottom key)
+   │       │        └── "Value" → 1000        ← column (bottom key)
+   │       │        └── "Unit" → kg/day       ← column (bottom key)   
    │       │
-   │       └── "Operating Capacity Factor (%)"
+   │       └── "Operating Capacity Factor"
    │                │
    │                └── "Value" → 90.0
+   │                └── "Unit" → '%''   
    │
    └── "Non-Depreciable Capital Costs"
    │       │
-   │       └── "Land required (acres)"
+   │       └── "Land required"
    │                │
-   │                └── "Value" → calculated by plugin
+   │                └── "Value" → Quantity object, calculated by plugin
    │				
 					
 					
@@ -110,20 +113,50 @@ It is important to note that this step **does not evaluate the entries** in the 
 It only converts their structure into Python objects so that they can later be processed by plugins when needed.
 
 
-5. Processing inputs: the ``process_table`` method
---------------------------------------------------
+5. Processing inputs: ``input_resolver_function`` 
+-------------------------------------------------
 
-When a plugin requires input data, it retrieves it from the dictionary using the ``process_table`` method.
+When a plugin requires input data, it retrieves it from the dictionary using ``input_resolver_function``.
 
-Each plugin typically begins by calling ``process_table`` for the entries it needs.  
-This call retrieves the actual value corresponding to the requested dictionary position.
+Each plugin file includes an ``input_dict`` dictionary containing the entry keys that are needed by the plugin (top, middle and bottom keys), as well as the characteristics of each entry (dimension, type etc).
 
-For example:
+For example, in ``Hourly_Irradiation__Plugin``, the ``input_dict`` contains, among other items:
+
+.. code-block:: python
+	"Irradiance Area Parameters": {	
+      <...>,   
+		"Nominal operating temperature": {
+			"Value": {
+				"type": {float,},
+				"bounds": (250, 500),
+			},
+			"Unit": {
+				"dimension": "temperature",
+			},
+			"optional": False,
+			"description": "Nominal operating temperature of irradiated module."
+		},   
+      <...>,    
+   }
+
+which means that ``Hourly_Irradiation__Plugin`` uses, among others, the value of ``dcf.inp['Irradiance Area Parameters']['Nominal operating temperature']['Value']`` as an input.
+
+
+The ``__init__`` method of the plugin typically begins by a call to ``input_resolver_function``, for example . 
 
 .. code-block:: python
 
-   process_table(dcf.inp, 'Solar Concentrator', 'Value')
-   
+   input_resolver_function(input_dict, dcf, 'Hourly_Irradiation_Plugin')
+
+This call retrieves the items corresponding to the dictionary positions found in input_dict, and apply a succession of conversion and sanity checks (dimensionality vs. unit consistency ; conversion into a specific unit ; bounds check).   
+
+In our example: 
+ 1. ``dcf.inp['Irradiance Area Parameters']['Nominal operating temperature']['Value']`` is retrieved. 
+ 2. A Quantity object is created from the Value and the related Unit (``dcf.inp['Irradiance Area Parameters']['Nominal operating temperature']['Unit']``). This step is bypassed if the Value is already a Quantity object.
+ 3. The input resolver checks if the unit of measurement is consistent with the expected dimension as per the input_dict (in the present case: temperature). If this is not the case, an error message is thrown.
+ 4. The input resolver checks if the value expressed in the Base unit (generally: SI unit) respects the ``bounds`` specified in input_dict. An operating temperature below 250 K or above 500 K would be unrealistic, and would therefore lead to an error message.
+ 5. The Quantity object is added to the local ``input_dict_resolved`` dictionary. The quantities present in this dictionary are the ones used within the plugin for all the calculations.
+ 
 
 One important feature of pyH2A is that table entries in the input file do not necessarily contain numerical values.  
 They can instead refer to other variables or paths.
@@ -134,19 +167,21 @@ For example, in ``PV_E_Base.md`` :
 
 	# Irradiance Area Parameters
 
-	Name | Value | Comment
+	Name | Value | Unit | Comment
 	--- | --- | ---
-	Module Tilt (degrees) | Hourly Irradiation > Latitude > Value | Module tilt equal to latitude of location.
+	Module Tilt | Hourly Irradiation > Latitude > Value | deg | Module tilt equal to latitude of location.
 
 Here the entry points to another variable in the dictionary.
 
-When Hourly_Irradiation_Plugin executes ``process_table(dcf.inp, 'Hourly Irradiation', 'Value')``, the corresponding entry ``dcf.inp['Irradiance Area Parameters']['Module Tilt (degrees)']['Value']`` ultimately receives the value stored at: 
+When Hourly_Irradiation_Plugin executes ``input_resolver(dcf, input_dict)``, the ``dcf.inp['Irradiance Area Parameters']['Module Tilt']['Value']`` entry ultimately receives the value stored at: 
 
 .. code-block:: python
 
    dcf.inp[Hourly Irradiation']['Latitude']['Value']
    
 In the present example, it means that the value of the module tilt is simply made equal to the latitude.
+
+
 
 
 6. Value Processing and Path-Based Multiplication
@@ -247,10 +282,10 @@ Flexible rows and table groups provide a way to structure input files in a clear
 
 Users can separate different cost contributions into individual rows or tables for readability, while the plugin logic automatically aggregates them during the calculation.
 
-8. Inserting or Updating Values: the ``insert`` method
-------------------------------------------------------
+8. Inserting or Updating Values: the ``output_resolver`` method
+---------------------------------------------------------------
 
-After performing calculations, plugins store their results in the dictionary using the ``insert`` method.
+After performing calculations, plugins store their results in the dictionary using the ``output_resolver`` method.
 
 This method can either:
 
@@ -309,7 +344,7 @@ In other words, this operation updates:
 9. Dependency Between Plugins
 -----------------------------
 
-When a plugin requests a value from the dictionary using ``process_table``, the corresponding entry must already exist.
+When a plugin requests a value from the dictionary using ``input_resolver_function``, the corresponding entry must already exist.
 
 This entry must therefore have been:
 
@@ -333,24 +368,24 @@ The data flow can be represented schematically as:
       (shared calculation dictionary)
                 │
                 ▼
-        ┌──────────────────┐
-        │     Plugin 1     │
-        │  - process_table │
-        │  - calculations  │
-        │  - insert        │
-        └──────────────────┘
+        ┌────────────────────────────┐
+        │         Plugin 1           │
+        │ - input_resolver_function  │
+        │ - calculations             │
+        │ - output_resolver          │
+        └────────────────────────────┘
                 │
                 ▼
             dcf.inp
        (with newly inserted variables)
                 │
                 ▼
-        ┌──────────────────┐
-        │     Plugin 2     │
-        │  - process_table │
-        │  - calculations  │
-        │  - insert        │
-        └──────────────────┘
+        ┌────────────────────────────┐
+        │         Plugin 2           │
+        │ - input_resolver_function  │
+        │ - calculations             │
+        │ - output_resolver          │
+        └────────────────────────────┘
                 │
                 ▼
             dcf.inp

--- a/doc/dictionary_structure.rst
+++ b/doc/dictionary_structure.rst
@@ -46,7 +46,7 @@ For example, the input file ``Thermal_base.md`` contains the table:
 
    Name | Value | Unit
    --- | --- | ---
-   Operating Capacity Factor | 90.0 | %
+   Operating Capacity Factor | 90.0% | -
    Plant Design Capacity | 1,000 | kg/day
 
 After conversion into Python objects and processing the table, the value ``1000``  and the associated unit ``kg/day`` are stored as this dictionary keys' item:
@@ -67,12 +67,12 @@ Conceptually, the dictionary structure can be visualized as follows:
    │       ├── "Plant Design Capacity"        ← row (mid key)
    │       │        │
    │       │        └── "Value" → 1000        ← column (bottom key)
-   │       │        └── "Unit" → kg/day       ← column (bottom key)   
+   │       │        └── "Unit" → 'kg/day'       ← column (bottom key)   
    │       │
    │       └── "Operating Capacity Factor"
    │                │
-   │                └── "Value" → 90.0
-   │                └── "Unit" → '%''   
+   │                └── "Value" → 0.9
+   │                └── "Unit" → '-'   
    │
    └── "Non-Depreciable Capital Costs"
    │       │
@@ -116,11 +116,13 @@ It only converts their structure into Python objects so that they can later be p
 5. Processing inputs: ``input_resolver_function`` 
 -------------------------------------------------
 
+This paragraph gives an overview of how inputs are processed in each plugin. More detailed explanations :ref:`are provided separately <input_resolver_guide>`.
+
 When a plugin requires input data, it retrieves it from the dictionary using ``input_resolver_function``.
 
 Each plugin file includes an ``input_dict`` dictionary containing the entry keys that are needed by the plugin (top, middle and bottom keys), as well as the characteristics of each entry (dimension, type etc).
 
-For example, in ``Hourly_Irradiation__Plugin``, the ``input_dict`` contains, among other items:
+For example, in ``Hourly_Irradiation_Plugin``, the ``input_dict`` contains, among other items:
 
 .. code-block:: python
 	"Irradiance Area Parameters": {	
@@ -146,7 +148,7 @@ The ``__init__`` method of the plugin typically begins by a call to ``input_reso
 
 .. code-block:: python
 
-   input_resolver_function(input_dict, dcf, 'Hourly_Irradiation_Plugin')
+   self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Hourly_Irradiation_Plugin')
 
 This call retrieves the items corresponding to the dictionary positions found in input_dict, and apply a succession of conversion and sanity checks (dimensionality vs. unit consistency ; conversion into a specific unit ; bounds check).   
 
@@ -155,7 +157,7 @@ In our example:
  2. A Quantity object is created from the Value and the related Unit (``dcf.inp['Irradiance Area Parameters']['Nominal operating temperature']['Unit']``). This step is bypassed if the Value is already a Quantity object.
  3. The input resolver checks if the unit of measurement is consistent with the expected dimension as per the input_dict (in the present case: temperature). If this is not the case, an error message is thrown.
  4. The input resolver checks if the value expressed in the Base unit (generally: SI unit) respects the ``bounds`` specified in input_dict. An operating temperature below 250 K or above 500 K would be unrealistic, and would therefore lead to an error message.
- 5. The Quantity object is added to the local ``input_dict_resolved`` dictionary. The quantities present in this dictionary are the ones used within the plugin for all the calculations.
+ 5. The Quantity object is added to the local ``self.input_dict_resolved`` dictionary. The quantities present in this dictionary are the ones used within the plugin for all the calculations.
  
 
 One important feature of pyH2A is that table entries in the input file do not necessarily contain numerical values.  
@@ -173,7 +175,7 @@ For example, in ``PV_E_Base.md`` :
 
 Here the entry points to another variable in the dictionary.
 
-When Hourly_Irradiation_Plugin executes ``input_resolver(dcf, input_dict)``, the ``dcf.inp['Irradiance Area Parameters']['Module Tilt']['Value']`` entry ultimately receives the value stored at: 
+When Hourly_Irradiation_Plugin executes ``input_resolver_function``, the ``dcf.inp['Irradiance Area Parameters']['Module Tilt']['Value']`` entry ultimately receives the value stored at: 
 
 .. code-block:: python
 
@@ -198,10 +200,10 @@ For example, in ``PEC_Base.md``:
 
    # Direct Capital Costs - Water Management
 
-   Name | Value | Path | Comment
+   Name | Value | Path | Unit | Comment
    --- | --- | --- | ---
-   Water pump ($) | 213.0 | None | Based on Pinaud 2013.
-   Water Manifold Piping ($ per cell) | 11.58 | PEC Cells > Number > Value |
+   Water pump | 213.0 | None | USD | Based on Pinaud 2013.
+   Water Manifold Piping | 11.58 | USD | PEC Cells > Number > Value |
 
 The entry indicates that the cost of water manifold piping is **11.58 $ per cell**.  
 The total cost therefore depends on the number of PEC cells defined elsewhere in the model.
@@ -222,7 +224,7 @@ This multiplication is performed automatically when the table entry is processed
 
   .. admonition:: Code implementation
 
-     The multiplication is handled by the ``process_input()`` method, which is called internally by ``process_table()``. If a ``Path`` column exists, the value retrieved from that path is multiplied with the entry in the ``Value`` column, and the resulting number replaces the original value in the dictionary.
+     The multiplication is handled by the ``process_input()`` method, which is called internally by ``input_resolver_function``. If a ``Path`` column exists, the value retrieved from that path is multiplied with the entry in the ``Value`` column, and the resulting number replaces the original value in the dictionary.
 
 
 7. Flexible Rows and Table Groups
@@ -242,7 +244,7 @@ For example, in the ``Variable_Operating_Cost_Plugin`` the method ``other_variab
 .. code-block:: python
 
    self.other = dcf.chemical_inflator * sum_all_tables(dcf.inp,'Other Variable Operating Cost','Value',
-       insert_total = True, class_object = dcf, print_info = print_info
+       insert_total = True, class_object = dcf, print_info = print_info, unit = 'USD'
    )
 
 In this case, the individual row names inside the table do not influence the calculation.  
@@ -261,7 +263,7 @@ For example, in ``Fixed_Operating_Cost_Plugin`` the method ``other_cost`` perfor
 .. code-block:: python
 
    self.other = sum_all_tables(dcf.inp, 'Other Fixed Operating Cost', 'Value',
-       insert_total = True, class_object = dcf, print_info = print_info
+       insert_total = True, class_object = dcf, print_info = print_info, unit = 'USD'
    ) * dcf.combined_inflator
 
 Here, every table whose name contains the string ``Other Fixed Operating Cost`` is included in the calculation.
@@ -278,67 +280,82 @@ Each table can contain its own entries, but all their values are combined when t
 Purpose of These Mechanisms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Flexible rows and table groups provide a way to structure input files in a clear and modular way.
+Flexible rows and table groups enable to structure input files in a clear and modular way.
 
 Users can separate different cost contributions into individual rows or tables for readability, while the plugin logic automatically aggregates them during the calculation.
 
-8. Inserting or Updating Values: the ``output_resolver`` method
----------------------------------------------------------------
+8. Inserting or Updating Values: ``output_inserter_function``
+-------------------------------------------------------------
 
-After performing calculations, plugins store their results in the dictionary using the ``output_resolver`` method.
+This paragraph gives an overview of how each plugin makes its calculated Quantites available in the dictionary. More detailed explanations :ref:`are provided separately <output_inserter_guide>`.
+
+After performing calculations, plugins store their results in the dictionary using the ``output_inserter_function`` call.
 
 This method can either:
 
 - create a **new dictionary entry**, or
 - **update the value** of an existing entry.
 
+The variable to be inserted at a given dictionary location is defined in the output_dict structure that is found in each plugin
+
 Example: in ``Solar_Concentrator_Plugin``
+
+- The output_dict structure contains 
+.. code-block:: python
+   "Non-Depreciable Capital Costs": {
+      "Land required": {
+         "Value": {
+               "inserted_value": "total_land_area",
+               "type": {float,},
+               "dimension": "area",
+         },
+         "optional": False,
+      },
+      "Solar Collection Area": {
+         "Value": {
+               "inserted_value": "total_solar_collection_area",
+               "type": {float,},
+               "dimension": "area",
+         },
+         "optional": False,
+      },      
 
 - creating a new entry:
 
-The variable ``total_land_area_acres`` is calculated and inserted with:
+The variable ``self.total_land_area`` is calculated in the plugin, and the call to ``output_inserter_function(output_dict, self, dcf, 'Solar_Concentrator_Plugin')`` creates the following dictionary entry to make it equal to ``self.total_land_area``:
 
 .. code-block:: python
 
-   insert(
-       dcf,
-       'Non-Depreciable Capital Costs', 'Land required (acres)', 'Value',
-       self.total_land_area_acres,
-       __name__,print_info = print_info
-   )
-
-This creates the dictionary entry:
-
-.. code-block:: python
-
-   dcf.inp['Non-Depreciable Capital Costs']['Land required (acres)']['Value']
+   dcf.inp['Non-Depreciable Capital Costs']['Land required']['Value']
 
 
 - updating an existing entry.
 
-The plugin reads the existing values of the ``Non-Depreciable Capital Costs`` table, including the existing value of the ``Solar Collection Area (m2)`` row:
+The plugin reads the existing values of the ``Non-Depreciable Capital Costs`` table, including the existing value of the ``Solar Collection Area`` row, as specified in the ``input_dict``:
 
 .. code-block:: python
 
-   process_table(dcf.inp, 'Non-Depreciable Capital Costs', 'Value')
+	"Non-Depreciable Capital Costs": {
+		"Solar collection area": {
+			"Value": {
+				"type": {float,},
+				"bounds": (0, None),
+			},
+			"Unit": {
+				"dimension": "area",
+			},
+			"optional": False,
+			"description": "Total solar collection area."
+		},
 
 
-A new value ``total_solar_collection_area_m2`` is calculated, and its value is assigned to ``dcf.inp['Non-Depreciable Capital Costs']['Solar Collection Area (m2)']['Value']``:
-
-.. code-block:: python
-
-   insert(
-       dcf,
-       'Non-Depreciable Capital Costs', 'Solar Collection Area (m2)','Value',
-       self.total_solar_collection_area_m2,
-       __name__,print_info = print_info
-   )
+A new value ``self.total_solar_collection_area`` is calculated, and its value is assigned to ``dcf.inp['Non-Depreciable Capital Costs']['Solar Collection Area']['Value']``, as seen in the ``output_dict`` above.
 
 In other words, this operation updates:
 
 .. code-block:: python
 
-   dcf.inp['Non-Depreciable Capital Costs']['Solar Collection Area (m2)']['Value']
+   dcf.inp['Non-Depreciable Capital Costs']['Solar Collection Area']['Value']
 
 
 9. Dependency Between Plugins

--- a/doc/dictionary_structure.rst
+++ b/doc/dictionary_structure.rst
@@ -125,19 +125,20 @@ Each plugin file includes an ``input_dict`` dictionary containing the entry keys
 For example, in ``Hourly_Irradiation_Plugin``, the ``input_dict`` contains, among other items:
 
 .. code-block:: python
-	"Irradiance Area Parameters": {	
+
+   "Irradiance Area Parameters": {	
       <...>,   
-		"Nominal operating temperature": {
-			"Value": {
-				"type": {float,},
-				"bounds": (250, 500),
-			},
-			"Unit": {
-				"dimension": "absolute_temperature",
-			},
-			"optional": False,
-			"description": "Nominal operating temperature of irradiated module."
-		},   
+      "Nominal operating temperature": {
+         "Value": {
+            "type": {float,},
+            "bounds": (250, 500),
+         },
+         "Unit": {
+            "dimension": "absolute_temperature",
+         },
+         "optional": False,
+         "description": "Nominal operating temperature of irradiated module."
+      },   
       <...>,    
    }
 
@@ -290,7 +291,9 @@ The variable to be inserted at a given dictionary location is defined in the out
 Example: in ``Solar_Concentrator_Plugin``
 
 - The output_dict structure contains 
+
 .. code-block:: python
+
    "Non-Depreciable Capital Costs": {
       "Land required": {
          "Value": {

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -45,7 +45,7 @@ This header request the :class:`~pyH2A.Analysis.Monte_Carlo_Analysis` module.
 Generate input file template
 ============================
 
-The input file containing the ``Workflow`` tabe and possible analysis headings is the starting point to generate the full input file template.
+The input file containing the ``Workflow`` table and possible analysis headings is the starting point to generate the full input file template.
 
 At this point the input file may look like this:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,8 @@ pyH2A
    :caption: Contents
 
    guide
+   Overview
+   dictionary_structure
    pyH2A/pyH2A
    utilities/utilities
    plugins/plugins

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,7 @@ pyH2A
    :caption: Contents
 
    guide
-   Overview
+   Overview   
    dictionary_structure
    pyH2A/pyH2A
    utilities/utilities

--- a/doc/plugins/Battery_Plugin.rst
+++ b/doc/plugins/Battery_Plugin.rst
@@ -1,0 +1,5 @@
+Battery_Plugin
+===================
+
+.. automodule:: pyH2A.Plugins.Battery_Plugin
+    :members:

--- a/doc/plugins/Battery_Plugin.rst
+++ b/doc/plugins/Battery_Plugin.rst
@@ -1,5 +1,120 @@
 Battery_Plugin
-===================
+==============
+
+For each operating year :math:`y`, the battery storage model calculates the recoverable stored energy and the remaining unstored energy on a daily basis.
+
+
+Equations
+---------
+
+Battery capacity degradation is first applied:
+
+.. math::
+
+   f_{\mathrm{cap},y} =
+   \left(1 - \lambda_{\mathrm{cap}}\right)^y
+
+.. math::
+
+   E_{\mathrm{bat},y}^{\mathrm{avail}} =
+   E_{\mathrm{bat}}^{\mathrm{design}}
+   \cdot
+   \left(1 - f_{\mathrm{discharge,min}}\right)
+   \cdot
+   f_{\mathrm{cap},y}
+
+For each day :math:`d` of year :math:`y`, the stored energy is limited by the available energy and the available battery capacity:
+
+.. math::
+
+   E_{\mathrm{stored},d,y}
+   =
+   \min
+   \left(
+   E_{\mathrm{avail},d,y},
+   E_{\mathrm{bat},y}^{\mathrm{avail}}
+   \right)
+
+The recoverable stored energy after round-trip efficiency losses is:
+
+.. math::
+
+   E_{\mathrm{recovered},d,y}
+   =
+   E_{\mathrm{stored},d,y}
+   \cdot
+   \eta_{\mathrm{rt}}
+
+
+The available daily energy is updated after storage:
+
+.. math::
+
+   E_{\mathrm{avail},d,y}^{\mathrm{updated}}
+   =
+   E_{\mathrm{avail},d,y}
+   -
+   E_{\mathrm{stored},d,y}
+
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`E_{\mathrm{avail},d,y}`
+     - Initial available energy for day :math:`d` in year :math:`y`
+       before battery storage
+       (``Power Generation > Available energy (daily) > Value`` input)
+     - energy
+
+   * - :math:`E_{\mathrm{avail},d,y}^{\mathrm{updated}}`
+     - Available energy remaining after battery storage
+       (``Power Generation > Available energy (daily) > Value`` output)
+     - energy
+
+   * - :math:`E_{\mathrm{bat}}^{\mathrm{design}}`
+     - Battery design capacity
+     - energy
+
+   * - :math:`f_{\mathrm{discharge,min}}`
+     - Lowest discharge level
+     - dimensionless
+
+   * - :math:`\lambda_{\mathrm{cap}}`
+     - Capacity loss per year
+     - dimensionless
+
+   * - :math:`f_{\mathrm{cap},y}`
+     - Remaining battery capacity fraction in year :math:`y`
+     - dimensionless
+
+   * - :math:`E_{\mathrm{bat},y}^{\mathrm{avail}}`
+     - Available battery capacity in year :math:`y`
+     - energy
+
+   * - :math:`\eta_{\mathrm{rt}}`
+     - Battery round-trip efficiency
+     - dimensionless
+
+   * - :math:`E_{\mathrm{stored},d,y}`
+     - Energy stored in the battery on day :math:`d`
+     - energy
+
+   * - :math:`E_{\mathrm{recovered},d,y}`
+     - Recoverable stored energy after round-trip efficiency losses
+     - energy
+
+
+Implementation
+--------------
 
 .. automodule:: pyH2A.Plugins.Battery_Plugin
     :members:

--- a/doc/plugins/Capital_Cost_Plugin.rst
+++ b/doc/plugins/Capital_Cost_Plugin.rst
@@ -4,135 +4,218 @@ Capital_Cost_Plugin
 This plugin computes the different components of capital costs based on grouped cost entries and applies inflation factors.
 
 Equations
-~~~~~~~~~
+---------
 
-Direct capital costs:
+Direct capital costs
+~~~~~~~~~~~~~~~~~~~~
 
-.. math::
-
-   C_{\text{direct}} = \sum_i C_{\text{direct},i}
-
-.. math::
-
-   C_{\text{direct}}^{\text{infl}} = C_{\text{direct}} \cdot f_{\text{infl,combined}}
-
-
-Indirect capital costs:
+The total direct capital cost is obtained by summing all entries belonging to the ``Direct Capital Cost`` table group:
 
 .. math::
 
-   C_{\text{indirect}} = \sum_j C_{\text{indirect},j}
+   C_{\mathrm{direct}} = \sum_i C_{\mathrm{direct},i}
+
+The inflated direct capital cost is then:
 
 .. math::
 
-   C_{\text{indirect}}^{\text{infl}} = C_{\text{indirect}} \cdot f_{\text{infl,combined}}
+   C_{\mathrm{direct}}^{\mathrm{inflated}}
+   =
+   C_{\mathrm{direct}} \times f_{\mathrm{combined}}
 
+Indirect capital costs
+~~~~~~~~~~~~~~~~~~~~~~
 
-Depreciable capital costs:
-
-.. math::
-
-   C_{\text{depr}} = C_{\text{direct}} + C_{\text{indirect}}
-
-.. math::
-
-   C_{\text{depr}}^{\text{infl}} = C_{\text{direct}}^{\text{infl}} + C_{\text{indirect}}^{\text{infl}}
-
-
-Non-depreciable capital costs:
+The total indirect capital cost is obtained by summing all entries belonging to the ``Indirect Capital Cost`` table group:
 
 .. math::
 
-   C_{\text{land}} = c_{\text{land}} \cdot A_{\text{land}}
+   C_{\mathrm{indirect}} = \sum_i C_{\mathrm{indirect},i}
+
+The inflated indirect capital cost is:
 
 .. math::
 
-   C_{\text{non-depr}} = C_{\text{land}} + \sum_k C_{\text{other non-depr},k}
+   C_{\mathrm{indirect}}^{\mathrm{inflated}}
+   =
+   C_{\mathrm{indirect}} \times f_{\mathrm{combined}}
+
+Non-depreciable capital costs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The land cost contribution is calculated as:
 
 .. math::
 
-   C_{\text{non-depr}}^{\text{infl}} = C_{\text{non-depr}} \cdot f_{\text{infl,CI}}
+   C_{\mathrm{land}}
+   =
+   c_{\mathrm{land}}
+   \times
+   A_{\mathrm{land}}
 
+where:
 
-Total capital costs:
+- :math:`c_{\mathrm{land}}` is the land cost per unit area
+- :math:`A_{\mathrm{land}}` is the required land area
+
+Additional non-depreciable contributions are summed from the ``Other Non-Depreciable Capital Cost`` table group:
 
 .. math::
 
-   C_{\text{total}} = C_{\text{depr}} + C_{\text{non-depr}}
+   C_{\mathrm{other\_nondep}}
+   =
+   \sum_i C_{\mathrm{other\_nondep},i}
+
+The total non-depreciable capital cost is therefore:
 
 .. math::
 
-   C_{\text{total}}^{\text{infl}} = C_{\text{depr}}^{\text{infl}} + C_{\text{non-depr}}^{\text{infl}}
+   C_{\mathrm{nondep}}
+   =
+   C_{\mathrm{land}}
+   +
+   C_{\mathrm{other\_nondep}}
+
+The inflated non-depreciable capital cost is:
+
+.. math::
+
+   C_{\mathrm{nondep}}^{\mathrm{inflated}}
+   =
+   C_{\mathrm{nondep}}
+   \times
+   f_{\mathrm{CI}}
+
+Depreciable and total capital costs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The depreciable capital cost is defined as:
+
+.. math::
+
+   C_{\mathrm{depreciable}}
+   =
+   C_{\mathrm{direct}}
+   +
+   C_{\mathrm{indirect}}
+
+The inflated depreciable capital cost is:
+
+.. math::
+
+   C_{\mathrm{depreciable}}^{\mathrm{inflated}}
+   =
+   C_{\mathrm{direct}}^{\mathrm{inflated}}
+   +
+   C_{\mathrm{indirect}}^{\mathrm{inflated}}
+
+The total capital cost is:
+
+.. math::
+
+   C_{\mathrm{total}}
+   =
+   C_{\mathrm{depreciable}}
+   +
+   C_{\mathrm{nondep}}
+
+The inflated total capital cost is:
+
+.. math::
+
+   C_{\mathrm{total}}^{\mathrm{inflated}}
+   =
+   C_{\mathrm{depreciable}}^{\mathrm{inflated}}
+   +
+   C_{\mathrm{nondep}}^{\mathrm{inflated}}
 
 
 Notation
 ~~~~~~~~
 
 .. list-table::
+   :widths: 30 50 20
    :header-rows: 1
 
    * - Symbol
      - Description
      - Dimension
 
-   * - :math:`C_{\text{direct}}`
+   * - :math:`C_{\mathrm{direct}}`
      - Total direct capital costs
-     - Currency
+     - currency
 
-   * - :math:`C_{\text{direct},i}`
-     - Individual direct capital cost entries (from "Direct Capital Cost" tables)
-     - Currency
+   * - :math:`C_{\mathrm{direct},i}`
+     - Individual direct capital cost contribution
+     - currency
 
-   * - :math:`C_{\text{indirect}}`
+   * - :math:`C_{\mathrm{direct}}^{\mathrm{inflated}}`
+     - Inflated direct capital costs
+     - currency
+
+   * - :math:`C_{\mathrm{indirect}}`
      - Total indirect capital costs
-     - Currency
+     - currency
 
-   * - :math:`C_{\text{indirect},j}`
-     - Individual indirect capital cost entries (from "Indirect Capital Cost" tables)
-     - Currency
+   * - :math:`C_{\mathrm{indirect},i}`
+     - Individual indirect capital cost contribution
+     - currency
 
-   * - :math:`C_{\text{depr}}`
-     - Total depreciable capital costs (direct + indirect)
-     - Currency
+   * - :math:`C_{\mathrm{indirect}}^{\mathrm{inflated}}`
+     - Inflated indirect capital costs
+     - currency
 
-   * - :math:`C_{\text{non-depr}}`
-     - Total non-depreciable capital costs
-     - Currency
+   * - :math:`c_{\mathrm{land}}`
+     - Cost of land
+     - currency / area
 
-   * - :math:`C_{\text{other non-depr},k}`
-     - Individual non-depreciable cost entries (excluding land)
-     - Currency
+   * - :math:`A_{\mathrm{land}}`
+     - Land required
+     - area
 
-   * - :math:`C_{\text{land}}`
+   * - :math:`C_{\mathrm{land}}`
      - Total land cost
-     - Currency
+     - currency
 
-   * - :math:`c_{\text{land}}`
-     - Cost of land per area  
-       (``Non-Depreciable Capital Costs > Cost of land ($ per acre) > Value``)
-     - Currency / area
+   * - :math:`C_{\mathrm{other\_nondep}}`
+     - Sum of other non-depreciable capital cost contributions
+     - currency
 
-   * - :math:`A_{\text{land}}`
-     - Land required  
-       (``Non-Depreciable Capital Costs > Land required (acres) > Value``)
-     - Area
+   * - :math:`C_{\mathrm{other\_nondep},i}`
+     - Individual other non-depreciable capital cost contribution
+     - currency
 
-   * - :math:`C_{\text{total}}`
+   * - :math:`C_{\mathrm{nondep}}`
+     - Total non-depreciable capital costs
+     - currency
+
+   * - :math:`C_{\mathrm{nondep}}^{\mathrm{inflated}}`
+     - Inflated non-depreciable capital costs
+     - currency
+
+   * - :math:`C_{\mathrm{depreciable}}`
+     - Total depreciable capital costs
+     - currency
+
+   * - :math:`C_{\mathrm{depreciable}}^{\mathrm{inflated}}`
+     - Inflated depreciable capital costs
+     - currency
+
+   * - :math:`C_{\mathrm{total}}`
      - Total capital costs
-     - Currency
+     - currency
 
-   * - :math:`f_{\text{infl,combined}}`
-     - Combined inflation factor (``dcf.combined_inflator``)
-     - Dimensionless
+   * - :math:`C_{\mathrm{total}}^{\mathrm{inflated}}`
+     - Inflated total capital costs
+     - currency
 
-   * - :math:`f_{\text{infl,CI}}`
-     - Capital investment inflation factor (``dcf.ci_inflator``)
-     - Dimensionless
+   * - :math:`f_{\mathrm{combined}}`
+     - Combined inflator
+     - dimensionless
 
-   * - Superscript :math:`\text{infl}`
-     - Indicates inflated value
-     - 
-
+   * - :math:`f_{\mathrm{CI}}`
+     - Capital inflator
+     - dimensionless
 
 Implementation
 --------------

--- a/doc/plugins/Capital_Cost_Plugin.rst
+++ b/doc/plugins/Capital_Cost_Plugin.rst
@@ -1,5 +1,141 @@
 Capital_Cost_Plugin
 ===================
 
+This plugin computes the different components of capital costs based on grouped cost entries and applies inflation factors.
+
+Equations
+~~~~~~~~~
+
+Direct capital costs:
+
+.. math::
+
+   C_{\text{direct}} = \sum_i C_{\text{direct},i}
+
+.. math::
+
+   C_{\text{direct}}^{\text{infl}} = C_{\text{direct}} \cdot f_{\text{infl,combined}}
+
+
+Indirect capital costs:
+
+.. math::
+
+   C_{\text{indirect}} = \sum_j C_{\text{indirect},j}
+
+.. math::
+
+   C_{\text{indirect}}^{\text{infl}} = C_{\text{indirect}} \cdot f_{\text{infl,combined}}
+
+
+Depreciable capital costs:
+
+.. math::
+
+   C_{\text{depr}} = C_{\text{direct}} + C_{\text{indirect}}
+
+.. math::
+
+   C_{\text{depr}}^{\text{infl}} = C_{\text{direct}}^{\text{infl}} + C_{\text{indirect}}^{\text{infl}}
+
+
+Non-depreciable capital costs:
+
+.. math::
+
+   C_{\text{land}} = c_{\text{land}} \cdot A_{\text{land}}
+
+.. math::
+
+   C_{\text{non-depr}} = C_{\text{land}} + \sum_k C_{\text{other non-depr},k}
+
+.. math::
+
+   C_{\text{non-depr}}^{\text{infl}} = C_{\text{non-depr}} \cdot f_{\text{infl,CI}}
+
+
+Total capital costs:
+
+.. math::
+
+   C_{\text{total}} = C_{\text{depr}} + C_{\text{non-depr}}
+
+.. math::
+
+   C_{\text{total}}^{\text{infl}} = C_{\text{depr}}^{\text{infl}} + C_{\text{non-depr}}^{\text{infl}}
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`C_{\text{direct}}`
+     - Total direct capital costs
+     - Currency
+
+   * - :math:`C_{\text{direct},i}`
+     - Individual direct capital cost entries (from "Direct Capital Cost" tables)
+     - Currency
+
+   * - :math:`C_{\text{indirect}}`
+     - Total indirect capital costs
+     - Currency
+
+   * - :math:`C_{\text{indirect},j}`
+     - Individual indirect capital cost entries (from "Indirect Capital Cost" tables)
+     - Currency
+
+   * - :math:`C_{\text{depr}}`
+     - Total depreciable capital costs (direct + indirect)
+     - Currency
+
+   * - :math:`C_{\text{non-depr}}`
+     - Total non-depreciable capital costs
+     - Currency
+
+   * - :math:`C_{\text{other non-depr},k}`
+     - Individual non-depreciable cost entries (excluding land)
+     - Currency
+
+   * - :math:`C_{\text{land}}`
+     - Total land cost
+     - Currency
+
+   * - :math:`c_{\text{land}}`
+     - Cost of land per area  
+       (``Non-Depreciable Capital Costs > Cost of land ($ per acre) > Value``)
+     - Currency / area
+
+   * - :math:`A_{\text{land}}`
+     - Land required  
+       (``Non-Depreciable Capital Costs > Land required (acres) > Value``)
+     - Area
+
+   * - :math:`C_{\text{total}}`
+     - Total capital costs
+     - Currency
+
+   * - :math:`f_{\text{infl,combined}}`
+     - Combined inflation factor (``dcf.combined_inflator``)
+     - Dimensionless
+
+   * - :math:`f_{\text{infl,CI}}`
+     - Capital investment inflation factor (``dcf.ci_inflator``)
+     - Dimensionless
+
+   * - Superscript :math:`\text{infl}`
+     - Indicates inflated value
+     - 
+
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Capital_Cost_Plugin
     :members:

--- a/doc/plugins/Catalyst_Separation_Plugin.rst
+++ b/doc/plugins/Catalyst_Separation_Plugin.rst
@@ -1,5 +1,80 @@
 Catalyst_Separation_Plugin
 ==========================
 
+Equations
+---------
+
+The yearly fraction of water requiring catalyst separation is determined from the catalyst lifetime:
+
+.. math::
+
+   f_{\mathrm{filter}}
+   =
+   \frac{1}{t_{\mathrm{cat}}}
+
+The yearly filtration volume is then:
+
+.. math::
+
+   V_{\mathrm{filter,year}}
+   =
+   V_{\mathrm{water}}
+   \cdot
+   f_{\mathrm{filter}}
+
+The yearly catalyst separation cost is:
+
+.. math::
+
+   C_{\mathrm{sep,year}}
+   =
+   V_{\mathrm{filter,year}}
+   \cdot
+   c_{\mathrm{filter}}
+
+The resulting yearly cost corresponds to:
+
+``Other Variable Operating Cost - Catalyst Separation > Catalyst separation (yearly cost) > Value``
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`V_{\mathrm{water}}`
+     - Total water volume
+     - volume
+
+   * - :math:`t_{\mathrm{cat}}`
+     - Catalyst lifetime before replacement is required
+     - time
+
+   * - :math:`f_{\mathrm{filter}}`
+     - Fraction of total water volume requiring filtration each year
+     - 1 / time
+
+   * - :math:`V_{\mathrm{filter,year}}`
+     - Water volume filtered per year
+     - volume
+
+   * - :math:`c_{\mathrm{filter}}`
+     - Filtration cost per unit volume
+     - currency / volume
+
+   * - :math:`C_{\mathrm{sep,year}}`
+     - Yearly catalyst separation cost
+     - currency
+
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Catalyst_Separation_Plugin
     :members:

--- a/doc/plugins/Electrolyzer_Plugin.rst
+++ b/doc/plugins/Electrolyzer_Plugin.rst
@@ -1,0 +1,5 @@
+Electrolyzer_Plugin
+===================
+
+.. automodule:: pyH2A.Plugins.Electrolyzer_Plugin
+    :members:

--- a/doc/plugins/Electrolyzer_Plugin.rst
+++ b/doc/plugins/Electrolyzer_Plugin.rst
@@ -1,5 +1,353 @@
 Electrolyzer_Plugin
 ===================
 
+Equations
+---------
+
+For each operating year :math:`y`, the electrolyzer power demand is increased to account for stack degradation:
+
+.. math::
+
+   f_{\mathrm{power},y}
+   =
+   \left(
+   1 + r_{\mathrm{power}}
+   \right)^y
+
+.. math::
+
+   P_{\mathrm{el},y}
+   =
+   P_{\mathrm{el}}^{\mathrm{nom}}
+   \cdot
+   f_{\mathrm{power},y}
+
+The hourly electrolyzer energy demand is:
+
+.. math::
+
+   E_{\mathrm{el},h,y}^{\mathrm{demand}}
+   =
+   3600
+   \cdot
+   P_{\mathrm{el},y}
+
+For each hourly timestep :math:`h`, the consumed energy is limited by the available energy:
+
+.. math::
+
+   E_{\mathrm{el},h,y}^{\mathrm{cons}}
+   =
+   \min
+   \left(
+   E_{\mathrm{avail},h,y},
+   E_{\mathrm{el},h,y}^{\mathrm{demand}}
+   \right)
+
+The instantaneous electrolyzer capacity factor is:
+
+.. math::
+
+   f_{\mathrm{cap},h,y}
+   =
+   \frac{
+   E_{\mathrm{el},h,y}^{\mathrm{cons}}
+   }{
+   E_{\mathrm{el},h,y}^{\mathrm{demand}}
+   }
+
+Electrolyzer operation is only allowed when the minimum operating capacity is reached:
+
+.. math::
+
+   \chi_{h,y}
+   =
+   \begin{cases}
+   1 & \text{if } f_{\mathrm{cap},h,y} > f_{\mathrm{min}} \\
+   0 & \text{if } f_{\mathrm{cap},h,y} \leq f_{\mathrm{min}}
+   \end{cases}
+
+The effective hourly energy consumption is therefore:
+
+.. math::
+
+   E_{\mathrm{el},h,y}^{\mathrm{eff}}
+   =
+   E_{\mathrm{el},h,y}^{\mathrm{cons}}
+   \cdot
+   \chi_{h,y}
+
+The hydrogen production during each hourly timestep is:
+
+.. math::
+
+   m_{\mathrm{H2},h,y}
+   =
+   \frac{
+   E_{\mathrm{el},h,y}^{\mathrm{eff}}
+   \cdot
+   \eta_{\mathrm{H2}}
+   }{
+   f_{\mathrm{power},y}
+   }
+
+The yearly hydrogen production is:
+
+.. math::
+
+   m_{\mathrm{H2},y}
+   =
+   \sum_h
+   m_{\mathrm{H2},h,y}
+
+The yearly electrolyzer operating duration is:
+
+.. math::
+
+   t_{\mathrm{op},y}
+   =
+   \sum_h
+   \chi_{h,y}
+
+The remaining unused hourly energy is:
+
+.. math::
+
+   E_{\mathrm{unused},h,y}
+   =
+   E_{\mathrm{avail},h,y}
+   -
+   E_{\mathrm{el},h,y}^{\mathrm{eff}}
+
+The daily unused energy is obtained by aggregating the hourly unused energy:
+
+.. math::
+
+   E_{\mathrm{unused},d,y}
+   =
+   \sum_{h \in d}
+   E_{\mathrm{unused},h,y}
+
+The plant design capacity is constructed from yearly hydrogen production data, including construction years during which production is zero:
+
+.. math::
+
+   \dot{m}_{\mathrm{plant}}
+   =
+   \left[
+   \underbrace{0,\dots,0}_{t_{\mathrm{construction}}},
+   m_{\mathrm{H2},1},
+   m_{\mathrm{H2},2},
+   \dots
+   \right]
+
+The operating capacity factor is fixed to:
+
+.. math::
+
+   f_{\mathrm{op}} = 1
+
+The cumulative electrolyzer operating time is:
+
+.. math::
+
+   t_{\mathrm{cum},y}
+   =
+   \sum_{i=1}^{y}
+   t_{\mathrm{op},i}
+
+The stack usage ratio is:
+
+.. math::
+
+   u_{\mathrm{stack},y}
+   =
+   \frac{
+   t_{\mathrm{cum},y}
+   }{
+   t_{\mathrm{replace}}
+   }
+
+The total number of stack replacements is:
+
+.. math::
+
+   N_{\mathrm{replace}}
+   =
+   \left\lfloor
+   u_{\mathrm{stack},Y}
+   \right\rfloor
+
+where :math:`Y` is the final operating year.
+
+The replacement frequency is then calculated as:
+
+.. math::
+
+   t_{\mathrm{replace,freq}}
+   =
+   \frac{
+   N_{\mathrm{years}}
+   }{
+   N_{\mathrm{replace}} + 1
+   }
+
+The electrolyzer CAPEX scaling factor is calculated from the number of ten-fold increases relative to the reference power:
+
+.. math::
+
+   N_{10}
+   =
+   \log_{10}
+   \left(
+   \frac{
+   P_{\mathrm{el}}^{\mathrm{nom}}
+   }{
+   P_{\mathrm{ref}}
+   }
+   \right)
+
+.. math::
+
+   f_{\mathrm{CAPEX}}
+   =
+   M_{\mathrm{CAPEX}}^{N_{10}}
+
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`E_{\mathrm{avail},h,y}`
+     - Available hourly energy for timestep :math:`h` in year :math:`y`
+     - energy
+
+   * - :math:`P_{\mathrm{el}}^{\mathrm{nom}}`
+     - Electrolyzer nominal power
+     - power
+
+   * - :math:`P_{\mathrm{ref}}`
+     - Electrolyzer CAPEX reference power
+     - power
+
+   * - :math:`r_{\mathrm{power}}`
+     - Power requirement increase per year
+     - dimensionless
+
+   * - :math:`f_{\mathrm{power},y}`
+     - Electrolyzer power increase ratio for year :math:`y`
+     - dimensionless
+
+   * - :math:`P_{\mathrm{el},y}`
+     - Electrolyzer power demand during year :math:`y`
+     - power
+
+   * - :math:`E_{\mathrm{el},h,y}^{\mathrm{demand}}`
+     - Hourly electrolyzer energy demand
+     - energy
+
+   * - :math:`E_{\mathrm{el},h,y}^{\mathrm{cons}}`
+     - Hourly electrolyzer energy consumption before minimum-capacity filtering
+     - energy
+
+   * - :math:`f_{\mathrm{cap},h,y}`
+     - Instantaneous electrolyzer operating capacity fraction
+     - dimensionless
+
+   * - :math:`f_{\mathrm{min}}`
+     - Minimum electrolyzer operating capacity
+     - dimensionless
+
+   * - :math:`\chi_{h,y}`
+     - Binary operating-state indicator
+     - dimensionless
+
+   * - :math:`E_{\mathrm{el},h,y}^{\mathrm{eff}}`
+     - Effective hourly electrolyzer energy consumption
+     - energy
+
+   * - :math:`\eta_{\mathrm{H2}}`
+     - Hydrogen yield per unit energy
+     - mass / energy
+
+   * - :math:`m_{\mathrm{H2},h,y}`
+     - Hydrogen produced during hourly timestep :math:`h`
+     - mass
+
+   * - :math:`m_{\mathrm{H2},y}`
+     - Total yearly hydrogen production
+     - mass
+
+   * - :math:`t_{\mathrm{op},y}`
+     - Electrolyzer operating duration during year :math:`y`
+     - time
+
+   * - :math:`E_{\mathrm{unused},h,y}`
+     - Unused hourly energy after electrolysis
+     - energy
+
+   * - :math:`E_{\mathrm{unused},d,y}`
+     - Daily unused energy after electrolysis
+     - energy
+
+   * - :math:`\dot{m}_{\mathrm{plant}}`
+     - Plant design capacity
+     - mass / time
+
+   * - :math:`f_{\mathrm{op}}`
+     - Operating capacity factor
+     - dimensionless
+
+   * - :math:`t_{\mathrm{construction}}`
+     - Construction time
+     - time
+
+   * - :math:`t_{\mathrm{cum},y}`
+     - Cumulative electrolyzer operating time up to year :math:`y`
+     - time
+
+   * - :math:`t_{\mathrm{replace}}`
+     - Electrolyzer stack replacement time
+     - time
+
+   * - :math:`u_{\mathrm{stack},y}`
+     - Stack usage ratio
+     - dimensionless
+
+   * - :math:`N_{\mathrm{replace}}`
+     - Number of stack replacements
+     - dimensionless
+
+   * - :math:`N_{\mathrm{years}}`
+     - Total number of operating years
+     - dimensionless
+
+   * - :math:`t_{\mathrm{replace,freq}}`
+     - Electrolyzer stack replacement frequency
+     - time
+
+   * - :math:`M_{\mathrm{CAPEX}}`
+     - CAPEX multiplier
+     - dimensionless
+
+   * - :math:`N_{10}`
+     - Number of ten-fold increases relative to the CAPEX reference power
+     - dimensionless
+
+   * - :math:`f_{\mathrm{CAPEX}}`
+     - Electrolyzer CAPEX scaling factor
+     - dimensionless
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Electrolyzer_Plugin
     :members:

--- a/doc/plugins/Fixed_Operating_Cost_Plugin.rst
+++ b/doc/plugins/Fixed_Operating_Cost_Plugin.rst
@@ -126,5 +126,8 @@ Notation
      - Combined inflation factor
      - dimensionless
 
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Fixed_Operating_Cost_Plugin
     :members:

--- a/doc/plugins/Fixed_Operating_Cost_Plugin.rst
+++ b/doc/plugins/Fixed_Operating_Cost_Plugin.rst
@@ -4,83 +4,127 @@ Fixed_Operating_Cost_Plugin
 This plugin computes yearly fixed operating costs, including labor costs and other fixed operating expenses.
 
 Equations
-~~~~~~~~~
+---------
 
-Yearly labor cost (uninflated):
+Labor costs
+~~~~~~~~~~~
 
-.. math::
-
-   C_{\text{labor}}^{\text{uninfl}} = N_{\text{staff}} \cdot c_{\text{labor}} \cdot 2080
-
-Yearly labor cost (inflated):
+The yearly uninflated labor cost is calculated as:
 
 .. math::
 
-   C_{\text{labor}} = C_{\text{labor}}^{\text{uninfl}} \cdot f_{\text{infl,labor}}
+   C_{\mathrm{labor}}^{\mathrm{uninflated}}
+   =
+   N_{\mathrm{staff}}
+   \times
+   c_{\mathrm{labor,hour}}
+   \times
+   t_{\mathrm{work,year}}
 
+where:
 
-Other fixed operating costs:
+- :math:`N_{\mathrm{staff}}` is the number of staff
+- :math:`c_{\mathrm{labor,hour}}` is the hourly labor cost
+- :math:`t_{\mathrm{work,year}} = 2080 \ \mathrm{h}` is the assumed yearly working time per staff member
+
+The inflated yearly labor cost is then:
 
 .. math::
 
-   C_{\text{fixed,other}} = \left( \sum_i C_{\text{fixed,other},i} \right) \cdot f_{\text{infl,combined}}
+   C_{\mathrm{labor}}
+   =
+   C_{\mathrm{labor}}^{\mathrm{uninflated}}
+   \times
+   f_{\mathrm{labor}}
 
+where:
 
-Total fixed operating costs:
+- :math:`f_{\mathrm{labor}}` is the labor inflator
+
+Other fixed operating costs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Additional fixed operating costs are obtained by summing all entries belonging to the ``Other Fixed Operating Cost`` table group:
 
 .. math::
 
-   C_{\text{fixed,total}} = C_{\text{labor}} + C_{\text{fixed,other}}
+   C_{\mathrm{other\ fixed}}
+   =
+   \left(
+   \sum_i C_{\mathrm{other\ fixed},i}
+   \right)
+   \times
+   f_{\mathrm{combined}}
+
+where:
+
+- :math:`C_{\mathrm{other\ fixed},i}` are the individual fixed operating cost contributions
+- :math:`f_{\mathrm{combined}}` is the combined inflator
+
+Total fixed operating costs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The total yearly fixed operating cost is:
+
+.. math::
+
+   C_{\mathrm{fixed,total}}
+   =
+   C_{\mathrm{labor}}
+   +
+   C_{\mathrm{other\ fixed}}
 
 
 Notation
 ~~~~~~~~
 
 .. list-table::
+   :widths: 30 50 20
    :header-rows: 1
 
    * - Symbol
      - Description
      - Dimension
 
-   * - :math:`N_{\text{staff}}`
-     - Number of staff  
-       (``Fixed Operating Costs > staff > Value``)
-     - Dimensionless
+   * - :math:`N_{\mathrm{staff}}`
+     - Number of staff
+     - dimensionless
 
-   * - :math:`c_{\text{labor}}`
-     - Hourly labor cost  
-       (``Fixed Operating Costs > hourly labor cost > Value``)
-     - Currency / time
+   * - :math:`c_{\mathrm{labor,hour}}`
+     - Hourly labor cost
+     - currency / time
 
-   * - :math:`C_{\text{labor}}^{\text{uninfl}}`
-     - Yearly labor cost (before inflation)
-     - Currency
+   * - :math:`t_{\mathrm{work,year}}`
+     - Working hours in a year
+     - time
 
-   * - :math:`C_{\text{labor}}`
-     - Yearly labor cost (after applying labor inflator)
-     - Currency
+   * - :math:`C_{\mathrm{labor}}^{\mathrm{uninflated}}`
+     - Yearly labor cost before labor inflation
+     - currency
 
-   * - :math:`C_{\text{fixed,other},i}`
-     - Individual other fixed operating cost entries  
-       (from "Other Fixed Operating Cost" tables)
-     - Currency
+   * - :math:`C_{\mathrm{labor}}`
+     - Yearly labor cost after applying labor inflator
+     - currency
 
-   * - :math:`C_{\text{fixed,other}}`
-     - Total other fixed operating costs (after inflation)
-     - Currency
+   * - :math:`C_{\mathrm{other\ fixed},i}`
+     - Individual other fixed operating cost contribution
+     - currency
 
-   * - :math:`C_{\text{fixed,total}}`
+   * - :math:`C_{\mathrm{other\ fixed}}`
+     - Total other fixed operating costs
+     - currency
+
+   * - :math:`C_{\mathrm{fixed,total}}`
      - Total yearly fixed operating costs
-     - Currency
+     - currency
 
-   * - :math:`f_{\text{infl,labor}}`
-     - Labor inflation factor (``dcf.labor_inflator``)
-     - Dimensionless
+   * - :math:`f_{\mathrm{labor}}`
+     - Labor inflation factor
+     - dimensionless
 
-   * - :math:`f_{\text{infl,combined}}`
-     - Combined inflation factor (``dcf.combined_inflator``)
-     - Dimensionless
+   * - :math:`f_{\mathrm{combined}}`
+     - Combined inflation factor
+     - dimensionless
 
 .. automodule:: pyH2A.Plugins.Fixed_Operating_Cost_Plugin
     :members:

--- a/doc/plugins/Fixed_Operating_Cost_Plugin.rst
+++ b/doc/plugins/Fixed_Operating_Cost_Plugin.rst
@@ -1,5 +1,86 @@
 Fixed_Operating_Cost_Plugin
 ===========================
 
+This plugin computes yearly fixed operating costs, including labor costs and other fixed operating expenses.
+
+Equations
+~~~~~~~~~
+
+Yearly labor cost (uninflated):
+
+.. math::
+
+   C_{\text{labor}}^{\text{uninfl}} = N_{\text{staff}} \cdot c_{\text{labor}} \cdot 2080
+
+Yearly labor cost (inflated):
+
+.. math::
+
+   C_{\text{labor}} = C_{\text{labor}}^{\text{uninfl}} \cdot f_{\text{infl,labor}}
+
+
+Other fixed operating costs:
+
+.. math::
+
+   C_{\text{fixed,other}} = \left( \sum_i C_{\text{fixed,other},i} \right) \cdot f_{\text{infl,combined}}
+
+
+Total fixed operating costs:
+
+.. math::
+
+   C_{\text{fixed,total}} = C_{\text{labor}} + C_{\text{fixed,other}}
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`N_{\text{staff}}`
+     - Number of staff  
+       (``Fixed Operating Costs > staff > Value``)
+     - Dimensionless
+
+   * - :math:`c_{\text{labor}}`
+     - Hourly labor cost  
+       (``Fixed Operating Costs > hourly labor cost > Value``)
+     - Currency / time
+
+   * - :math:`C_{\text{labor}}^{\text{uninfl}}`
+     - Yearly labor cost (before inflation)
+     - Currency
+
+   * - :math:`C_{\text{labor}}`
+     - Yearly labor cost (after applying labor inflator)
+     - Currency
+
+   * - :math:`C_{\text{fixed,other},i}`
+     - Individual other fixed operating cost entries  
+       (from "Other Fixed Operating Cost" tables)
+     - Currency
+
+   * - :math:`C_{\text{fixed,other}}`
+     - Total other fixed operating costs (after inflation)
+     - Currency
+
+   * - :math:`C_{\text{fixed,total}}`
+     - Total yearly fixed operating costs
+     - Currency
+
+   * - :math:`f_{\text{infl,labor}}`
+     - Labor inflation factor (``dcf.labor_inflator``)
+     - Dimensionless
+
+   * - :math:`f_{\text{infl,combined}}`
+     - Combined inflation factor (``dcf.combined_inflator``)
+     - Dimensionless
+
 .. automodule:: pyH2A.Plugins.Fixed_Operating_Cost_Plugin
     :members:

--- a/doc/plugins/Hourly_Irradiation_Plugin.rst
+++ b/doc/plugins/Hourly_Irradiation_Plugin.rst
@@ -1,5 +1,390 @@
 Hourly_Irradiation_Plugin
 =========================
 
+The hourly irradiation model calculates the plane-of-array irradiation and resulting solar power density for three configurations:
+
+- fixed tilt (no tracking),
+- horizontal single-axis tracking,
+- dual-axis tracking.
+
+
+Equations
+---------
+
+If the module tilt is not specified, it defaults to the absolute latitude:
+
+.. math::
+
+   \beta = |\phi|
+
+The solar declination angle is calculated as:
+
+.. math::
+
+   \delta_d
+   =
+   23.45^\circ
+   \sin\left(
+   \frac{2\pi}{365}(d - 81)
+   \right)
+
+The solar hour angle is:
+
+.. math::
+
+   \omega_h
+   =
+   15^\circ
+   (t_h - 12)
+   +
+   \lambda
+
+The solar altitude angle is:
+
+.. math::
+
+   \alpha_h
+   =
+   \arcsin
+   \left(
+   \sin(\delta_d)\sin(\phi)
+   +
+   \cos(\delta_d)\cos(\phi)\cos(\omega_h)
+   \right)
+
+The solar azimuth angle is:
+
+.. math::
+
+   \gamma_h
+   =
+   \arccos
+   \left(
+   \frac{
+   \sin(\delta_d)\cos(\phi)
+   -
+   \cos(\delta_d)\sin(\phi)\cos(\omega_h)
+   }{
+   \cos(\alpha_h)
+   }
+   \right)
+   \cdot
+   \mathrm{sign}(\omega_h)
+
+For the fixed-tilt configuration, the direct normal irradiance projection factor is:
+
+.. math::
+
+   f_{\mathrm{DNI},h}
+   =
+   \cos(\alpha_h)\sin(\beta)\cos(\gamma_{\mathrm{arr}} - \gamma_h)
+   +
+   \sin(\alpha_h)\cos(\beta)
+
+Negative values are clipped to zero.
+
+The direct plane-of-array irradiation is:
+
+.. math::
+
+   G_{\mathrm{dir},h}
+   =
+   G_{\mathrm{DNI},h}
+   \cdot
+   f_{\mathrm{DNI},h}
+
+The diffuse plane-of-array irradiation is:
+
+.. math::
+
+   G_{\mathrm{diff},h}
+   =
+   G_{\mathrm{DHI},h}
+   \cdot
+   \frac{180^\circ - \beta}{180^\circ}
+
+The total plane-of-array irradiation is:
+
+.. math::
+
+   G_{\mathrm{POA},h}
+   =
+   G_{\mathrm{dir},h}
+   +
+   G_{\mathrm{diff},h}
+
+The cell temperature is estimated from the nominal operating temperature:
+
+.. math::
+
+   T_{\mathrm{cell},h}
+   =
+   T_{\mathrm{amb},h}
+   +
+   \left(
+   T_{\mathrm{NOCT}} - 20^\circ\mathrm{C}
+   \right)
+   \frac{
+   G_{\mathrm{POA},h}
+   }{
+   800
+   }
+
+The temperature derating factor is:
+
+.. math::
+
+   f_{\mathrm{temp},h}
+   =
+   1
+   +
+   \alpha_T
+   \left(
+   T_{\mathrm{cell},h} - 25^\circ\mathrm{C}
+   \right)
+
+The resulting hourly power density for the fixed-tilt configuration is:
+
+.. math::
+
+   P_h
+   =
+   f_{\mathrm{temp},h}
+   \cdot
+   f_{\mathrm{mismatch}}
+   \cdot
+   f_{\mathrm{dirt}}
+   \cdot
+   G_{\mathrm{POA},h}
+
+This corresponds to:
+
+``Hourly Irradiation > No tracking > Value``
+
+
+Horizontal single-axis tracking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For horizontal single-axis tracking, the tracking azimuth is:
+
+.. math::
+
+   \gamma_{\mathrm{SAT},h}
+   =
+   \mathrm{sign}(\gamma_h)
+   \frac{\pi}{2}
+
+The tracking tilt angle is:
+
+.. math::
+
+   \beta_{\mathrm{SAT},h}
+   =
+   \arctan
+   \left(
+   \frac{
+   \cos(\gamma_{\mathrm{SAT},h} - \gamma_h)
+   }{
+   \tan(\alpha_h)
+   }
+   \right)
+
+The corresponding irradiation projection factor is:
+
+.. math::
+
+   f_{\mathrm{SAT},h}
+   =
+   \cos(\alpha_h)\sin(\beta_{\mathrm{SAT},h})
+   \cos(\gamma_{\mathrm{SAT},h} - \gamma_h)
+   +
+   \sin(\alpha_h)\cos(\beta_{\mathrm{SAT},h})
+
+Negative values are clipped to zero.
+
+The single-axis tracking power density is:
+
+.. math::
+
+   P_{\mathrm{SAT},h}
+   =
+   f_{\mathrm{temp},h}
+   \cdot
+   f_{\mathrm{mismatch}}
+   \cdot
+   f_{\mathrm{dirt}}
+   \cdot
+   G_{\mathrm{POA,SAT},h}
+
+This corresponds to:
+
+``Hourly Irradiation > Horizontal single axis tracking > Value``
+
+
+Dual-axis tracking
+~~~~~~~~~~~~~~~~~~
+
+For dual-axis tracking, the model assumes direct normal irradiance is always normal to the module surface:
+
+.. math::
+
+   P_{\mathrm{DAT},h}
+   =
+   G_{\mathrm{DNI},h}
+   \cdot
+   f_{\mathrm{temp},h}
+   \cdot
+   f_{\mathrm{mismatch}}
+   \cdot
+   f_{\mathrm{dirt}}
+
+
+
+Yearly averaged power densities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The yearly averaged power densities are calculated as:
+
+.. math::
+
+   \overline{P}
+   =
+   \frac{
+   \sum_h P_h
+   }{
+   365 \times 24
+   }
+
+.. math::
+
+   \overline{P}_{\mathrm{SAT}}
+   =
+   \frac{
+   \sum_h P_{\mathrm{SAT},h}
+   }{
+   365 \times 24
+   }
+
+.. math::
+
+   \overline{P}_{\mathrm{DAT}}
+   =
+   \frac{
+   \sum_h P_{\mathrm{DAT},h}
+   }{
+   365 \times 24
+   }
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 30
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`\phi`
+     - Latitude
+     - angle
+
+   * - :math:`\lambda`
+     - Longitude
+     - angle
+
+   * - :math:`\beta`
+     - Module tilt
+     - angle
+
+   * - :math:`\gamma_{\mathrm{arr}}`
+     - Array azimuth
+     - angle
+
+   * - :math:`T_{\mathrm{NOCT}}`
+     - Nominal operating temperature
+     - absolute temperature
+
+   * - :math:`f_{\mathrm{mismatch}}`
+     - Mismatch derating factor
+     - dimensionless
+
+   * - :math:`f_{\mathrm{dirt}}`
+     - Dirt derating factor
+     - dimensionless
+
+   * - :math:`\alpha_T`
+     - Temperature coefficient
+     - 1 / temperature difference
+
+   * - :math:`\delta_d`
+     - Solar declination angle
+     - angle
+
+   * - :math:`\omega_h`
+     - Solar hour angle
+     - angle
+
+   * - :math:`\alpha_h`
+     - Solar altitude angle
+     - angle
+
+   * - :math:`\gamma_h`
+     - Solar azimuth angle
+     - angle
+
+   * - :math:`G_{\mathrm{DNI},h}`
+     - Direct normal irradiance
+     - power / area
+
+   * - :math:`G_{\mathrm{DHI},h}`
+     - Diffuse horizontal irradiance
+     - power / area
+
+   * - :math:`G_{\mathrm{POA},h}`
+     - Plane-of-array irradiance
+     - power / area
+
+   * - :math:`T_{\mathrm{amb},h}`
+     - Ambient temperature
+     - absolute temperature
+
+   * - :math:`T_{\mathrm{cell},h}`
+     - Solar cell temperature
+     - absolute temperature
+
+   * - :math:`f_{\mathrm{temp},h}`
+     - Temperature derating factor
+     - dimensionless
+
+   * - :math:`P_h`
+     - Hourly power density without tracking
+     - power / area
+
+   * - :math:`P_{\mathrm{SAT},h}`
+     - Hourly power density with horizontal single-axis tracking
+     - power / area
+
+   * - :math:`P_{\mathrm{DAT},h}`
+     - Hourly power density with dual-axis tracking
+     - power / area
+
+   * - :math:`\overline{P}`
+     - Mean solar input without tracking
+     - power / area
+
+   * - :math:`\overline{P}_{\mathrm{SAT}}`
+     - Mean solar input with horizontal single-axis tracking
+     - power / area
+
+   * - :math:`\overline{P}_{\mathrm{DAT}}`
+     - Mean solar input with dual-axis tracking
+     - power / area
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Hourly_Irradiation_Plugin
     :members:

--- a/doc/plugins/Multiple_Modules_Plugin.rst
+++ b/doc/plugins/Multiple_Modules_Plugin.rst
@@ -1,5 +1,111 @@
 Multiple_Modules_Plugin
 =======================
 
+The Multiple_Modules plugin determines the number of staff required to operate a plant made of multiple modules.
+
+Equations
+---------
+
+The total solar collection area across all plant modules is:
+
+.. math::
+
+   A_{\mathrm{total}}
+   =
+   N_{\mathrm{modules}}
+   \cdot
+   A_{\mathrm{solar,module}}
+
+The number of operating staff required for one shift is calculated as:
+
+.. math::
+
+   N_{\mathrm{staff,shift}}
+   =
+   \left\lceil
+   \frac{
+   A_{\mathrm{total}}
+   }{
+   A_{\mathrm{staff}}
+   }
+   \right\rceil
+   +
+   N_{\mathrm{supervisors}}
+
+where :math:`\lceil \cdot \rceil` denotes rounding upward to the nearest integer.
+
+The total number of 8-hour equivalent staff across all shifts is:
+
+.. math::
+
+   N_{\mathrm{staff,total}}
+   =
+   N_{\mathrm{staff,shift}}
+   \cdot
+   N_{\mathrm{shifts}}
+
+The resulting number of staff required per plant module is:
+
+.. math::
+
+   N_{\mathrm{staff,module}}
+   =
+   \frac{
+   N_{\mathrm{staff,total}}
+   }{
+   N_{\mathrm{modules}}
+   }
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 20
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`N_{\mathrm{modules}}`
+     - Number of plant modules considered in the calculation
+     - dimensionless
+
+   * - :math:`A_{\mathrm{solar,module}}`
+     - Solar collection area for one plant module
+     - area
+
+   * - :math:`A_{\mathrm{total}}`
+     - Total solar collection area across all plant modules
+     - area
+
+   * - :math:`A_{\mathrm{staff}}`
+     - Solar collection area that can be covered by one staffer
+     - area
+
+   * - :math:`N_{\mathrm{supervisors}}`
+     - Number of supervisors per shift
+     - dimensionless
+
+   * - :math:`N_{\mathrm{staff,shift}}`
+     - Number of staff required for one 8-hour shift
+     - dimensionless
+
+   * - :math:`N_{\mathrm{shifts}}`
+     - Number of 8-hour shifts
+     - dimensionless
+
+   * - :math:`N_{\mathrm{staff,total}}`
+     - Total number of 8-hour equivalent staff across all shifts
+     - dimensionless
+
+   * - :math:`N_{\mathrm{staff,module}}`
+     - Number of 8-hour equivalent staff required per plant module
+     - dimensionless
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Multiple_Modules_Plugin
     :members:

--- a/doc/plugins/PEC_Plugin.rst
+++ b/doc/plugins/PEC_Plugin.rst
@@ -1,5 +1,279 @@
 PEC_Plugin
 ==========
 
+The PEC plugin determines the number of cells, as well as various costs for photo-electrochemical hydrogen production.
+
+Equations
+---------
+
+The area of a single PEC cell is:
+
+.. math::
+
+   A_{\mathrm{cell}}
+   =
+   L_{\mathrm{cell}}
+   \cdot
+   W_{\mathrm{cell}}
+
+The solar power incident on one PEC cell is:
+
+.. math::
+
+   P_{\mathrm{solar,cell}}
+   =
+   A_{\mathrm{cell}}
+   \cdot
+   I_{\mathrm{solar}}
+
+The hydrogen molar production rate per cell is:
+
+.. math::
+
+   \dot{n}_{\mathrm{H_2,cell}}
+   =
+   \frac{
+   P_{\mathrm{solar,cell}}
+   \cdot
+   \eta_{\mathrm{STH}}
+   }{
+   E_{\mathrm{H_2}}
+   }
+
+The hydrogen mass production rate per cell is:
+
+.. math::
+
+   \dot{m}_{\mathrm{H_2,cell}}
+   =
+   \dot{n}_{\mathrm{H_2,cell}}
+   \cdot
+   M_{\mathrm{H_2}}
+
+The hydrogen molar production rate per collection area is:
+
+.. math::
+
+   \dot{n}_{\mathrm{H_2,surf}}
+   =
+   \frac{
+   \dot{n}_{\mathrm{H_2,cell}}
+   }{
+   A_{\mathrm{cell}}
+   }
+
+The cost of a single PEC cell is:
+
+.. math::
+
+   C_{\mathrm{cell}}
+   =
+   A_{\mathrm{cell}}
+   \cdot
+   c_{\mathrm{cell}}
+
+The number of PEC cells required to satisfy the design output flowrate is:
+
+.. math::
+
+   N_{\mathrm{cell}}
+   =
+   \left\lceil
+   \frac{
+   \dot{m}_{\mathrm{design}}
+   }{
+   \dot{m}_{\mathrm{H_2,cell}}
+   }
+   \right\rceil
+
+The total PEC cell cost is:
+
+.. math::
+
+   C_{\mathrm{PEC,total}}
+   =
+   N_{\mathrm{cell}}
+   \cdot
+   C_{\mathrm{cell}}
+
+The total solar collection area is:
+
+.. math::
+
+   A_{\mathrm{solar,total}}
+   =
+   A_{\mathrm{cell}}
+   \cdot
+   N_{\mathrm{cell}}
+
+The projected ground length occupied by one inclined PEC cell is:
+
+.. math::
+
+   L_{\mathrm{proj}}
+   =
+   L_{\mathrm{cell}}
+   \cdot
+   \cos(\theta_{\mathrm{cell}})
+
+The total ground length per PEC cell row is:
+
+.. math::
+
+   L_{\mathrm{row}}
+   =
+   L_{\mathrm{proj}}
+   +
+   s_{\mathrm{south}}
+
+The total ground width per PEC cell row is:
+
+.. math::
+
+   W_{\mathrm{row}}
+   =
+   W_{\mathrm{cell}}
+   +
+   s_{\mathrm{EW}}
+
+The total land area requirement is:
+
+.. math::
+
+   A_{\mathrm{land,total}}
+   =
+   L_{\mathrm{row}}
+   \cdot
+   W_{\mathrm{row}}
+   \cdot
+   N_{\mathrm{cell}}
+
+The PEC cell replacement frequency is equal to the PEC cell lifetime:
+
+.. math::
+
+   t_{\mathrm{replace}}
+   =
+   t_{\mathrm{cell}}
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 45
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`\dot{m}_{\mathrm{design}}`
+     - Design output flowrate
+     - mass / time
+
+   * - :math:`c_{\mathrm{cell}}`
+     - PEC cell cost per unit area
+     - currency / area
+
+   * - :math:`t_{\mathrm{cell}}`
+     - PEC cell lifetime
+     - time
+
+   * - :math:`L_{\mathrm{cell}}`
+     - PEC cell length
+     - length
+
+   * - :math:`W_{\mathrm{cell}}`
+     - PEC cell width
+     - length
+
+   * - :math:`A_{\mathrm{cell}}`
+     - Area of a single PEC cell
+     - area
+
+   * - :math:`\theta_{\mathrm{cell}}`
+     - PEC cell angle from the ground
+     - angle
+
+   * - :math:`s_{\mathrm{south}}`
+     - South spacing between PEC cells
+     - length
+
+   * - :math:`s_{\mathrm{EW}}`
+     - East/West spacing between PEC cells
+     - length
+
+   * - :math:`\eta_{\mathrm{STH}}`
+     - Solar-to-hydrogen efficiency
+     - dimensionless
+
+   * - :math:`I_{\mathrm{solar}}`
+     - Mean solar input
+     - power / area
+
+   * - :math:`P_{\mathrm{solar,cell}}`
+     - Solar power incident on one PEC cell
+     - power
+
+   * - :math:`E_{\mathrm{H_2}}`
+     - Energy required to produce one mole of hydrogen
+     - energy / amount of substance
+
+   * - :math:`M_{\mathrm{H_2}}`
+     - Molecular weight of hydrogen
+     - mass / amount of substance
+
+   * - :math:`\dot{n}_{\mathrm{H_2,cell}}`
+     - Hydrogen molar production rate per PEC cell
+     - amount of substance / time
+
+   * - :math:`\dot{m}_{\mathrm{H_2,cell}}`
+     - Hydrogen mass production rate per PEC cell
+     - mass / time
+
+   * - :math:`\dot{n}_{\mathrm{H_2,surf}}`
+     - Hydrogen molar production rate per collection area
+     - amount of substance / time / area
+
+   * - :math:`C_{\mathrm{cell}}`
+     - Cost of a single PEC cell
+     - currency
+
+   * - :math:`N_{\mathrm{cell}}`
+     - Number of PEC cells required
+     - dimensionless
+
+   * - :math:`C_{\mathrm{PEC,total}}`
+     - Total PEC cell cost
+     - currency
+
+   * - :math:`A_{\mathrm{solar,total}}`
+     - Total solar collection area
+     - area
+
+   * - :math:`L_{\mathrm{proj}}`
+     - Projected ground length of one inclined PEC cell
+     - length
+
+   * - :math:`L_{\mathrm{row}}`
+     - Total ground length per PEC cell row
+     - length
+
+   * - :math:`W_{\mathrm{row}}`
+     - Total ground width per PEC cell row
+     - length
+
+   * - :math:`A_{\mathrm{land,total}}`
+     - Total land area requirement
+     - area
+
+   * - :math:`t_{\mathrm{replace}}`
+     - PEC cell replacement frequency
+     - time
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.PEC_Plugin
     :members:

--- a/doc/plugins/Photocatalytic_Plugin.rst
+++ b/doc/plugins/Photocatalytic_Plugin.rst
@@ -1,5 +1,537 @@
 Photocatalytic_Plugin
 =====================
 
+The Photocatalytic plugin calcualtes the characteristics of a photocatalytic hydrogen production plant (number of baggies, water etc) and subsequent costs.
+
+Equations
+---------
+
+Hydrogen production per baggie
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The area of a single reactor baggie is:
+
+.. math::
+
+   A_{\mathrm{baggie}}
+   =
+   L_{\mathrm{baggie}}
+   \cdot
+   W_{\mathrm{baggie}}
+
+The mean solar power intercepted by one baggie is:
+
+.. math::
+
+   P_{\mathrm{solar,baggie}}
+   =
+   A_{\mathrm{baggie}}
+   \cdot
+   I_{\mathrm{solar}}
+
+The hydrogen molar production rate per baggie is:
+
+.. math::
+
+   \dot{n}_{\mathrm{H_2,baggie}}
+   =
+   \frac{
+   P_{\mathrm{solar,baggie}}
+   \cdot
+   \eta_{\mathrm{STH}}
+   }{
+   E_{\mathrm{H_2}}
+   }
+
+The hydrogen mass production rate per baggie is:
+
+.. math::
+
+   \dot{m}_{\mathrm{H_2,baggie}}
+   =
+   \dot{n}_{\mathrm{H_2,baggie}}
+   \cdot
+   MW_{\mathrm{H_2}}
+
+The required number of baggies is:
+
+.. math::
+
+   N_{\mathrm{baggie}}
+   =
+   \left\lceil
+   \frac{
+   \dot{m}_{\mathrm{design}}
+   }{
+   \dot{m}_{\mathrm{H_2,baggie}}
+   }
+   \right\rceil
+
+
+
+Baggie costs
+~~~~~~~~~~~~
+
+The material cost per baggie is:
+
+.. math::
+
+   C_{\mathrm{material,baggie}}
+   =
+   A_{\mathrm{baggie}}
+   \cdot
+   \left(
+   c_{\mathrm{top}}
+   +
+   c_{\mathrm{bottom}}
+   \right)
+
+The port cost per baggie is:
+
+.. math::
+
+   C_{\mathrm{port,baggie}}
+   =
+   N_{\mathrm{ports}}
+   \cdot
+   c_{\mathrm{port}}
+
+The total cost per baggie is:
+
+.. math::
+
+   C_{\mathrm{baggie,unit}}
+   =
+   f_{\mathrm{markup}}
+   \cdot
+   \left(
+   C_{\mathrm{material,baggie}}
+   +
+   C_{\mathrm{port,baggie}}
+   +
+   C_{\mathrm{other,baggie}}
+   \right)
+
+The total baggie cost is:
+
+.. math::
+
+   C_{\mathrm{baggie,total}}
+   =
+   N_{\mathrm{baggie}}
+   \cdot
+   C_{\mathrm{baggie,unit}}
+
+
+
+Catalyst inventory and catalyst cost
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The volume of a single baggie is:
+
+.. math::
+
+   V_{\mathrm{baggie}}
+   =
+   L_{\mathrm{baggie}}
+   \cdot
+   W_{\mathrm{baggie}}
+   \cdot
+   h_{\mathrm{fill}}
+
+The total reactor volume is:
+
+.. math::
+
+   V_{\mathrm{total}}
+   =
+   V_{\mathrm{baggie}}
+   \cdot
+   N_{\mathrm{baggie}}
+
+The catalyst mass per baggie is:
+
+.. math::
+
+   m_{\mathrm{cat,baggie}}
+   =
+   V_{\mathrm{baggie}}
+   \cdot
+   \rho_{\mathrm{cat}}
+
+The total catalyst inventory is:
+
+.. math::
+
+   m_{\mathrm{cat,total}}
+   =
+   m_{\mathrm{cat,baggie}}
+   \cdot
+   N_{\mathrm{baggie}}
+
+The total catalyst cost is:
+
+.. math::
+
+   C_{\mathrm{cat,total}}
+   =
+   m_{\mathrm{cat,total}}
+   \cdot
+   c_{\mathrm{cat}}
+
+
+
+Land area
+~~~~~~~~~
+
+The total solar collection area is:
+
+.. math::
+
+   A_{\mathrm{solar}}
+   =
+   N_{\mathrm{baggie}}
+   \cdot
+   A_{\mathrm{baggie}}
+
+The total required land area is:
+
+.. math::
+
+   A_{\mathrm{land}}
+   =
+   A_{\mathrm{solar}}
+   \cdot
+   \left(
+   1 +
+   f_{\mathrm{land,add}}
+   \right)
+
+
+
+Planned replacement quantities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The catalyst replacement frequency is equal to the catalyst lifetime:
+
+.. math::
+
+   t_{\mathrm{cat,replacement}}
+   =
+   t_{\mathrm{cat}}
+
+The baggie replacement frequency is equal to the baggie lifetime:
+
+.. math::
+
+   t_{\mathrm{baggie,replacement}}
+   =
+   t_{\mathrm{baggie}}
+
+The catalyst replacement cost is:
+
+.. math::
+
+   C_{\mathrm{cat,replacement}}
+   =
+   C_{\mathrm{cat,total}}
+
+The baggie replacement cost is:
+
+.. math::
+
+   C_{\mathrm{baggie,replacement}}
+   =
+   C_{\mathrm{baggie,total}}
+
+
+
+Catalyst activity calculations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The peak hydrogen production per unit area is:
+
+.. math::
+
+   \dot{n}_{\mathrm{H_2,peak}}
+   =
+   \frac{
+   E_{\mathrm{solar,peak}}
+   \cdot
+   \eta_{\mathrm{STH}}
+   }{
+   E_{\mathrm{H_2}}
+   }
+
+The catalyst mass per unit area is:
+
+.. math::
+
+   \Gamma_{\mathrm{cat}}
+   =
+   h_{\mathrm{fill}}
+   \cdot
+   \rho_{\mathrm{cat}}
+
+The peak catalyst activity is:
+
+.. math::
+
+   TOF_{\mathrm{peak,mass}}
+   =
+   \frac{
+   \dot{n}_{\mathrm{H_2,peak}}
+   }{
+   \Gamma_{\mathrm{cat}}
+   }
+
+The mean hydrogen production rate per unit area is:
+
+.. math::
+
+   \dot{n}_{\mathrm{H_2,mean}}
+   =
+   \frac{
+   I_{\mathrm{solar}}
+   \cdot
+   \eta_{\mathrm{STH}}
+   }{
+   E_{\mathrm{H_2}}
+   }
+
+
+
+Homogeneous catalyst calculations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the catalyst molar weight is provided, the catalyst concentration per volume is:
+
+.. math::
+
+   C_{\mathrm{cat,molar}}
+   =
+   \frac{
+   \rho_{\mathrm{cat}}
+   }{
+   MW_{\mathrm{cat}}
+   }
+
+The catalyst amount per unit area is:
+
+.. math::
+
+   \Gamma_{\mathrm{cat,molar}}
+   =
+   h_{\mathrm{fill}}
+   \cdot
+   C_{\mathrm{cat,molar}}
+
+The peak turnover frequency is:
+
+.. math::
+
+   TOF_{\mathrm{peak}}
+   =
+   \frac{
+   \dot{n}_{\mathrm{H_2,peak}}
+   }{
+   \Gamma_{\mathrm{cat,molar}}
+   }
+
+The mean daily turnover frequency is:
+
+.. math::
+
+   TOF_{\mathrm{mean}}
+   =
+   \frac{
+   \dot{n}_{\mathrm{H_2,mean,daily}}
+   }{
+   \Gamma_{\mathrm{cat,molar}}
+   }
+
+The turnover number is:
+
+.. math::
+
+   TON
+   =
+   TOF_{\mathrm{mean}}
+   \cdot
+   t_{\mathrm{cat}}
+
+If the molar attenuation coefficient is provided, the absorbance is:
+
+.. math::
+
+   Abs
+   =
+   C_{\mathrm{cat,molar}}
+   \cdot
+   h_{\mathrm{fill}}
+   \cdot
+   \varepsilon_{\mathrm{mol}}
+
+The absorbed light fraction is:
+
+.. math::
+
+   f_{\mathrm{abs}}
+   =
+   1 - 10^{-Abs}
+
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`\dot{m}_{\mathrm{design}}`
+     - Design output flowrate
+     - mass / time
+
+   * - :math:`L_{\mathrm{baggie}}`
+     - Baggie length
+     - length
+
+   * - :math:`W_{\mathrm{baggie}}`
+     - Baggie width
+     - length
+
+   * - :math:`h_{\mathrm{fill}}`
+     - Baggie filling height
+     - length
+
+   * - :math:`A_{\mathrm{baggie}}`
+     - Area of one reactor baggie
+     - area
+
+   * - :math:`V_{\mathrm{baggie}}`
+     - Volume of one reactor baggie
+     - volume
+
+   * - :math:`I_{\mathrm{solar}}`
+     - Mean solar input
+     - power / area
+
+   * - :math:`E_{\mathrm{solar,peak}}`
+     - Peak hourly solar irradiation
+       derived from
+     - energy / area
+
+   * - :math:`\eta_{\mathrm{STH}}`
+     - Solar-to-hydrogen efficiency
+     - dimensionless
+
+   * - :math:`E_{\mathrm{H_2}}`
+     - Energy required to produce one mole of hydrogen
+     - energy / substance
+
+   * - :math:`MW_{\mathrm{H_2}}`
+     - Molecular weight of hydrogen
+     - mass / substance
+
+   * - :math:`\dot{n}_{\mathrm{H_2,baggie}}`
+     - Hydrogen molar production rate per baggie
+     - substance / time
+
+   * - :math:`\dot{m}_{\mathrm{H_2,baggie}}`
+     - Hydrogen mass production rate per baggie
+     - mass / time
+
+   * - :math:`N_{\mathrm{baggie}}`
+     - Number of required reactor baggies
+     - dimensionless
+
+   * - :math:`c_{\mathrm{top}}`
+     - Cost of baggie top material
+     - currency / area
+
+   * - :math:`c_{\mathrm{bottom}}`
+     - Cost of baggie bottom material
+     - currency / area
+
+   * - :math:`N_{\mathrm{ports}}`
+     - Number of ports per baggie
+     - dimensionless
+
+   * - :math:`c_{\mathrm{port}}`
+     - Cost of one port
+     - currency
+
+   * - :math:`C_{\mathrm{other,baggie}}`
+     - Other costs per baggie
+     - currency
+
+   * - :math:`f_{\mathrm{markup}}`
+     - Baggie markup factor
+     - dimensionless
+
+   * - :math:`C_{\mathrm{baggie,total}}`
+     - Total baggie cost
+     - currency
+
+   * - :math:`\rho_{\mathrm{cat}}`
+     - Catalyst concentration
+     - mass / volume
+
+   * - :math:`m_{\mathrm{cat,total}}`
+     - Total catalyst mass
+     - mass
+
+   * - :math:`c_{\mathrm{cat}}`
+     - Catalyst cost per unit mass
+     - currency / mass
+
+   * - :math:`C_{\mathrm{cat,total}}`
+     - Total catalyst cost
+     - currency
+
+   * - :math:`A_{\mathrm{solar}}`
+     - Total solar collection area
+     - area
+
+   * - :math:`f_{\mathrm{land,add}}`
+     - Additional land area factor
+     - dimensionless
+
+   * - :math:`A_{\mathrm{land}}`
+     - Total required land area
+     - area
+
+   * - :math:`t_{\mathrm{cat}}`
+     - Catalyst lifetime
+     - time
+
+   * - :math:`t_{\mathrm{baggie}}`
+     - Baggie lifetime
+     - time
+
+   * - :math:`MW_{\mathrm{cat}}`
+     - Catalyst molar weight
+     - mass / substance
+
+   * - :math:`\varepsilon_{\mathrm{mol}}`
+     - Catalyst molar attenuation coefficient
+     - volume / (length \* substance)
+
+   * - :math:`Abs`
+     - Catalyst absorbance
+     - dimensionless
+
+   * - :math:`f_{\mathrm{abs}}`
+     - Fraction of absorbed light
+     - dimensionless
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Photocatalytic_Plugin
     :members:

--- a/doc/plugins/Photovoltaic_Plugin.rst
+++ b/doc/plugins/Photovoltaic_Plugin.rst
@@ -1,5 +1,164 @@
 Photovoltaic_Plugin
 ===================
 
+
+Equations
+---------
+
+Photovoltaic electricity production is calculated from time-resolved irradiation data, PV efficiency, installed capacity, and degradation effects.
+
+
+
+Yearly degradation factor:
+
+.. math::
+
+   f_{\mathrm{deg},y}
+   =
+   \left(1 - \lambda_{\mathrm{PV}}\right)^y
+
+
+
+Corrected irradiation (time-dependent):
+
+.. math::
+
+   I_{t,y}
+   =
+   I_t \cdot f_{\mathrm{deg},y}
+
+
+
+Instantaneous electrical power output:
+
+.. math::
+
+   P_{t,y}
+   =
+   I_{t,y} \cdot P_{\mathrm{PV}}^{\mathrm{nom}}
+
+
+
+Hourly energy production (1-hour resolution):
+
+.. math::
+
+   E_{t,y}
+   =
+   P_{t,y} \cdot \Delta t
+   \quad (\Delta t = 1\,\mathrm{h})
+
+
+
+Daily aggregation:
+
+.. math::
+
+   E_{\mathrm{day},y}
+   =
+   \sum_{t \in \mathrm{day}} E_{t,y}
+
+
+
+CAPEX scaling factor:
+
+.. math::
+
+   n_{\mathrm{10x}}
+   =
+   \log_{10}\!\left(
+   \frac{P_{\mathrm{PV}}^{\mathrm{nom}}}{P_{\mathrm{PV}}^{\mathrm{ref}}}
+   \right)
+
+.. math::
+
+   f_{\mathrm{CAPEX}}
+   =
+   m^{\,n_{\mathrm{10x}}}
+
+
+
+PV area requirement:
+
+.. math::
+
+   A_{\mathrm{PV}}
+   =
+   \frac{P_{\mathrm{PV}}^{\mathrm{nom}}}{\eta_{\mathrm{PV}} \cdot I_{\mathrm{peak}}}
+
+with :math:`I_{\mathrm{peak}} = 1\,\mathrm{kW/m^2}`.
+
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`I_t`
+     - Hourly irradiation data
+     - power / area
+
+   * - :math:`\lambda_{\mathrm{PV}}`
+     - PV power loss per year
+     - dimensionless
+
+   * - :math:`f_{\mathrm{deg},y}`
+     - Degradation correction factor in year :math:`y`
+     - dimensionless
+
+   * - :math:`P_{\mathrm{PV}}^{\mathrm{nom}}`
+     - Nominal PV power
+     - power
+
+   * - :math:`P_{\mathrm{PV}}^{\mathrm{ref}}`
+     - CAPEX reference power
+     - power
+
+   * - :math:`P_{t,y}`
+     - PV power output at time :math:`t` in year :math:`y`
+     - power
+
+   * - :math:`E_{t,y}`
+     - Hourly energy production
+     - energy
+
+   * - :math:`E_{\mathrm{day},y}`
+     - Daily energy production
+     - energy
+
+   * - :math:`m`
+     - CAPEX multiplier
+     - dimensionless
+
+   * - :math:`f_{\mathrm{CAPEX}}`
+     - PV CAPEX scaling factor
+     - dimensionless
+
+   * - :math:`P_{\mathrm{PV}}^{\mathrm{nom}} / P_{\mathrm{PV}}^{\mathrm{ref}}`
+     - Power scaling ratio used for CAPEX scaling
+     - dimensionless
+
+   * - :math:`\eta_{\mathrm{PV}}`
+     - PV efficiency
+     - dimensionless
+
+   * - :math:`A_{\mathrm{PV}}`
+     - Required PV collection area
+     - area
+
+   * - :math:`I_{\mathrm{peak}}`
+     - Peak solar irradiation assumption
+     - power / area
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Photovoltaic_Plugin
     :members:

--- a/doc/plugins/Power_Management_Plugin.rst
+++ b/doc/plugins/Power_Management_Plugin.rst
@@ -1,0 +1,5 @@
+Power_Management_Plugin
+===================
+
+.. automodule:: pyH2A.Plugins.Power_Management_Plugin
+    :members:

--- a/doc/plugins/Power_Management_Plugin.rst
+++ b/doc/plugins/Power_Management_Plugin.rst
@@ -1,5 +1,181 @@
 Power_Management_Plugin
-===================
+=======================
+
+The power management module allocates available and stored energy to different consumers and computes unmet demand and grid electricity usage.
+
+Equations
+---------
+
+The system manages two energy streams on a yearly basis:
+
+- flexible (directly available) energy
+- stored (battery) energy
+
+and allocates them sequentially to power consumers.
+
+Available and stored energy (yearly aggregation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Daily values are aggregated to yearly values:
+
+.. math::
+
+   E_{\mathrm{flex},y} = \sum_{d \in y} E_{\mathrm{avail},d,y}
+
+.. math::
+
+   E_{\mathrm{stor},y} = \sum_{d \in y} E_{\mathrm{stor},d,y}
+
+Power allocation
+~~~~~~~~~~~~~~~~
+
+Let the set of consumers be split into:
+
+- on-demand consumers :math:`\mathcal{C}_{\mathrm{on}}`
+- flexible consumers :math:`\mathcal{C}_{\mathrm{flex}}`
+
+1. On-demand consumers (stored energy only)
+
+For each year:
+
+.. math::
+
+   E_{\mathrm{stor},y}^{(1)} =
+   E_{\mathrm{stor},y}
+   -
+   \sum_{c \in \mathcal{C}_{\mathrm{on}}}
+   \min\left(D_{c,y}, E_{\mathrm{stor},y}\right)
+
+Unfulfilled demand:
+
+.. math::
+
+   U_{\mathrm{on},y}
+   =
+   \sum_{c \in \mathcal{C}_{\mathrm{on}}}
+   \max\left(D_{c,y} - E_{\mathrm{stor},y}, 0\right)
+
+
+
+2. Flexible consumers
+
+Flexible consumers first use flexible energy, then stored energy:
+
+Flexible allocation:
+
+.. math::
+
+   E_{\mathrm{flex},y}^{(1)} =
+   E_{\mathrm{flex},y}
+   -
+   \sum_{c \in \mathcal{C}_{\mathrm{flex}}}
+   \min\left(D_{c,y}, E_{\mathrm{flex},y}\right)
+
+Residual demand:
+
+.. math::
+
+   D_{c,y}^{\mathrm{res}} =
+   \max\left(D_{c,y} - E_{\mathrm{flex},y}, 0\right)
+
+Stored allocation:
+
+.. math::
+
+   E_{\mathrm{stor},y}^{(2)} =
+   E_{\mathrm{stor},y}^{(1)}
+   -
+   \sum_{c \in \mathcal{C}_{\mathrm{flex}}}
+   \min\left(D_{c,y}^{\mathrm{res}}, E_{\mathrm{stor},y}^{(1)}\right)
+
+Unfulfilled flexible demand:
+
+.. math::
+
+   U_{\mathrm{flex},y}
+   =
+   \sum_{c \in \mathcal{C}_{\mathrm{flex}}}
+   \max\left(D_{c,y}^{\mathrm{res}} - E_{\mathrm{stor},y}^{(1)}, 0\right)
+
+
+
+3. Total unfulfilled demand
+
+.. math::
+
+   U_{y} = U_{\mathrm{on},y} + U_{\mathrm{flex},y}
+
+
+
+4. Grid electricity cost
+
+Grid electricity compensates unmet demand:
+
+.. math::
+
+   C_{\mathrm{grid},y}
+   =
+   U_{y} \cdot p_{\mathrm{grid},y}
+
+where :math:`p_{\mathrm{grid},y}` is the electricity price.
+
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`E_{\mathrm{avail},d,y}`
+     - Available energy (daily input stream)
+     - energy
+
+   * - :math:`E_{\mathrm{stor},d,y}`
+     - Stored energy (daily input stream)
+     - energy
+
+   * - :math:`E_{\mathrm{flex},y}`
+     - Yearly flexible energy availability
+     - energy
+
+   * - :math:`E_{\mathrm{stor},y}`
+     - Yearly stored energy availability
+     - energy
+
+   * - :math:`D_{c,y}`
+     - Energy demand of consumer :math:`c`
+     - energy
+
+   * - :math:`\mathcal{C}_{\mathrm{on}}`
+     - Set of on-demand consumers
+     - dimensionless
+
+   * - :math:`\mathcal{C}_{\mathrm{flex}}`
+     - Set of flexible consumers
+     - dimensionless
+
+   * - :math:`U_{y}`
+     - Total unfulfilled energy demand
+     - energy
+
+   * - :math:`p_{\mathrm{grid},y}`
+     - Grid electricity cost per energy unit
+     - currency / energy
+
+   * - :math:`C_{\mathrm{grid},y}`
+     - Grid electricity cost
+     - currency
+
+
+Implementation
+--------------
+
 
 .. automodule:: pyH2A.Plugins.Power_Management_Plugin
     :members:

--- a/doc/plugins/Production_Scaling_Plugin.rst
+++ b/doc/plugins/Production_Scaling_Plugin.rst
@@ -83,7 +83,7 @@ Notation
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 50 20
+   :widths: 30 50 50
 
    * - Symbol
      - Description
@@ -140,6 +140,9 @@ Notation
    * - :math:`Q_{\mathrm{year,gate}}`
      - Output per year at gate
      - Functional unit dimension
+
+Implementation
+--------------     
 
 .. automodule:: pyH2A.Plugins.Production_Scaling_Plugin
     :members:

--- a/doc/plugins/Production_Scaling_Plugin.rst
+++ b/doc/plugins/Production_Scaling_Plugin.rst
@@ -1,5 +1,157 @@
 Production_Scaling_Plugin
 =========================
 
+This plugin computes plant output and optional scaling factors affecting subsequent capital and labor calculations.
+
+Equations
+~~~~~~~~~
+
+Default definitions:
+
+If not specified, the maximum output at gate is set equal to the plant design capacity:
+
+.. math::
+
+   Q_{\text{max,gate}} = Q_{\text{design}}
+
+
+Scaling ratio:
+
+If a new plant design capacity is provided:
+
+.. math::
+
+   R_{\text{scale}} = \frac{Q_{\text{design,new}}}{Q_{\text{design}}}
+
+
+Scaled daily outputs (if scaling is active):
+
+.. math::
+
+   Q_{\text{design,scaled}} = Q_{\text{design}} \cdot R_{\text{scale}}
+
+.. math::
+
+   Q_{\text{max,gate,scaled}} = Q_{\text{max,gate}} \cdot R_{\text{scale}}
+
+
+If no scaling is applied:
+
+.. math::
+
+   Q_{\text{design,scaled}} = Q_{\text{design}}
+
+.. math::
+
+   Q_{\text{max,gate,scaled}} = Q_{\text{max,gate}}
+
+
+Scaling factors (if scaling is active):
+
+.. math::
+
+   f_{\text{scale,cap}} = R_{\text{scale}}^{\alpha_{\text{cap}}}
+
+.. math::
+
+   f_{\text{scale,lab}} = R_{\text{scale}}^{\alpha_{\text{lab}}}
+
+If exponents are not specified:
+
+.. math::
+
+   \alpha_{\text{cap}} = 0.78
+
+.. math::
+
+   \alpha_{\text{lab}} = 0.25
+
+
+Yearly outputs:
+
+.. math::
+
+   Q_{\text{year}} = Q_{\text{design,scaled}} \cdot 365 \cdot f_{\text{op}}
+
+.. math::
+
+   Q_{\text{year,gate}} = Q_{\text{max,gate,scaled}} \cdot 365 \cdot f_{\text{op}}
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`Q_{\text{design}}`
+     - Plant design capacity  
+       (``Plant Design Capacity``)
+     - Mass / time
+
+   * - :math:`Q_{\text{design,new}}`
+     - New plant design capacity (for scaling)  
+       (``New Plant Design Capacity``)
+     - Mass / time
+
+   * - :math:`Q_{\text{max,gate}}`
+     - Maximum output at gate  
+       (``Maximum Output at Gate``)
+     - Mass / time
+
+   * - :math:`Q_{\text{design,scaled}}`
+     - Scaled design output per day  
+       (``Design Output per Day``)
+     - Mass / time
+
+   * - :math:`Q_{\text{max,gate,scaled}}`
+     - Scaled maximum gate output per day  
+       (``Max Gate Output per Day``)
+     - Mass / time
+
+   * - :math:`Q_{\text{year}}`
+     - Yearly hydrogen output  
+       (``Output per Year``)
+     - Mass
+
+   * - :math:`Q_{\text{year,gate}}`
+     - Yearly hydrogen output at gate  
+       (``Output per Year at Gate``)
+     - Mass
+
+   * - :math:`f_{\text{op}}`
+     - Operating capacity factor (fraction)  
+       (``Operating Capacity Factor (%)``)
+     - Dimensionless
+
+   * - :math:`R_{\text{scale}}`
+     - Scaling ratio  
+       (``Scaling Ratio``)
+     - Dimensionless
+
+   * - :math:`f_{\text{scale,cap}}`
+     - Capital scaling factor  
+       (``Scaling > Capital Scaling Factor``)
+     - Dimensionless
+
+   * - :math:`f_{\text{scale,lab}}`
+     - Labor scaling factor  
+       (``Scaling > Labor Scaling Factor``)
+     - Dimensionless
+
+   * - :math:`\alpha_{\text{cap}}`
+     - Capital scaling exponent  
+       (``Capital Scaling Exponent``; default = 0.78)
+     - Dimensionless
+
+   * - :math:`\alpha_{\text{lab}}`
+     - Labor scaling exponent  
+       (``Labor Scaling Exponent``; default = 0.25)
+     - Dimensionless
+
 .. automodule:: pyH2A.Plugins.Production_Scaling_Plugin
     :members:

--- a/doc/plugins/Production_Scaling_Plugin.rst
+++ b/doc/plugins/Production_Scaling_Plugin.rst
@@ -1,5 +1,5 @@
-Production_Scaling_Plugin Equations
------------------------------------
+Production_Scaling_Plugin
+-------------------------
 
 This plugin computes the delivered output and applies optional scaling relationships for plant capacity, capital costs, and labor costs.
 

--- a/doc/plugins/Production_Scaling_Plugin.rst
+++ b/doc/plugins/Production_Scaling_Plugin.rst
@@ -1,157 +1,145 @@
-Production_Scaling_Plugin
-=========================
+Production_Scaling_Plugin Equations
+-----------------------------------
 
-This plugin computes plant output and optional scaling factors affecting subsequent capital and labor calculations.
+This plugin computes the delivered output and applies optional scaling relationships for plant capacity, capital costs, and labor costs.
 
 Equations
-~~~~~~~~~
+---------
 
-Default definitions:
+Plant scaling
+~~~~~~~~~~~~~
 
-If not specified, the maximum output at gate is set equal to the plant design capacity:
-
-.. math::
-
-   Q_{\text{max,gate}} = Q_{\text{design}}
-
-
-Scaling ratio:
-
-If a new plant design capacity is provided:
+If a new plant size is specified, the scaling ratio is:
 
 .. math::
 
-   R_{\text{scale}} = \frac{Q_{\text{design,new}}}{Q_{\text{design}}}
+   R_{\mathrm{scale}} =
+   \frac{\dot{Q}_{\mathrm{design,new}}}
+   {\dot{Q}_{\mathrm{design}}}
 
+Alternatively, the scaling ratio can be provided directly as an input.
 
-Scaled daily outputs (if scaling is active):
-
-.. math::
-
-   Q_{\text{design,scaled}} = Q_{\text{design}} \cdot R_{\text{scale}}
-
-.. math::
-
-   Q_{\text{max,gate,scaled}} = Q_{\text{max,gate}} \cdot R_{\text{scale}}
-
-
-If no scaling is applied:
+The scaled design output is then:
 
 .. math::
 
-   Q_{\text{design,scaled}} = Q_{\text{design}}
+   \dot{Q}_{\mathrm{design,scaled}}
+   =
+   \dot{Q}_{\mathrm{design}}
+   \times
+   R_{\mathrm{scale}}
+
+Similarly, the maximum gate output rate becomes:
 
 .. math::
 
-   Q_{\text{max,gate,scaled}} = Q_{\text{max,gate}}
+   \dot{Q}_{\mathrm{gate,max}}
+   =
+   \dot{Q}_{\mathrm{gate,max,0}}
+   \times
+   R_{\mathrm{scale}}
 
-
-Scaling factors (if scaling is active):
-
-.. math::
-
-   f_{\text{scale,cap}} = R_{\text{scale}}^{\alpha_{\text{cap}}}
-
-.. math::
-
-   f_{\text{scale,lab}} = R_{\text{scale}}^{\alpha_{\text{lab}}}
-
-If exponents are not specified:
+Capital and labor scaling factors are calculated using power-law scaling:
 
 .. math::
 
-   \alpha_{\text{cap}} = 0.78
+   F_{\mathrm{cap}}
+   =
+   R_{\mathrm{scale}}^{n_{\mathrm{cap}}}
 
 .. math::
 
-   \alpha_{\text{lab}} = 0.25
+   F_{\mathrm{labor}}
+   =
+   R_{\mathrm{scale}}^{n_{\mathrm{labor}}}
 
+If no scaling is requested, the scaled quantities are equal to the original values.
 
-Yearly outputs:
+Yearly output
+~~~~~~~~~~~~~
+
+The yearly production output is calculated from the scaled design output and the operating capacity factor:
 
 .. math::
 
-   Q_{\text{year}} = Q_{\text{design,scaled}} \cdot 365 \cdot f_{\text{op}}
+   Q_{\mathrm{year}}
+   =
+   \dot{Q}_{\mathrm{design,scaled}}
+   \times
+   f_{\mathrm{op}}
+
+The yearly output at gate is:
 
 .. math::
 
-   Q_{\text{year,gate}} = Q_{\text{max,gate,scaled}} \cdot 365 \cdot f_{\text{op}}
-
+   Q_{\mathrm{year,gate}}
+   =
+   \dot{Q}_{\mathrm{gate,max}}
+   \times
+   f_{\mathrm{op}}
 
 Notation
 ~~~~~~~~
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 50 20
 
    * - Symbol
      - Description
      - Dimension
 
-   * - :math:`Q_{\text{design}}`
-     - Plant design capacity  
-       (``Plant Design Capacity``)
-     - Mass / time
+   * - :math:`\dot{Q}_{\mathrm{design}}`
+     - Plant design capacity
+     - Functional unit dimension / time
 
-   * - :math:`Q_{\text{design,new}}`
-     - New plant design capacity (for scaling)  
-       (``New Plant Design Capacity``)
-     - Mass / time
+   * - :math:`\dot{Q}_{\mathrm{design,new}}`
+     - New plant design capacity
+     - Functional unit dimension / time
 
-   * - :math:`Q_{\text{max,gate}}`
-     - Maximum output at gate  
-       (``Maximum Output at Gate``)
-     - Mass / time
-
-   * - :math:`Q_{\text{design,scaled}}`
-     - Scaled design output per day  
-       (``Design Output per Day``)
-     - Mass / time
-
-   * - :math:`Q_{\text{max,gate,scaled}}`
-     - Scaled maximum gate output per day  
-       (``Max Gate Output per Day``)
-     - Mass / time
-
-   * - :math:`Q_{\text{year}}`
-     - Yearly hydrogen output  
-       (``Output per Year``)
-     - Mass
-
-   * - :math:`Q_{\text{year,gate}}`
-     - Yearly hydrogen output at gate  
-       (``Output per Year at Gate``)
-     - Mass
-
-   * - :math:`f_{\text{op}}`
-     - Operating capacity factor (fraction)  
-       (``Operating Capacity Factor (%)``)
+   * - :math:`R_{\mathrm{scale}}`
+     - Scaling ratio
      - Dimensionless
 
-   * - :math:`R_{\text{scale}}`
-     - Scaling ratio  
-       (``Scaling Ratio``)
+   * - :math:`\dot{Q}_{\mathrm{design,scaled}}`
+     - Scaled design output rate
+     - Functional unit dimension / time
+
+   * - :math:`\dot{Q}_{\mathrm{gate,max,0}}`
+     - Initial maximum output rate at gate
+     - Functional unit dimension / time
+
+   * - :math:`\dot{Q}_{\mathrm{gate,max}}`
+     - Scaled maximum output rate at gate
+     - Functional unit dimension / time
+
+   * - :math:`n_{\mathrm{cap}}`
+     - Capital scaling exponent
      - Dimensionless
 
-   * - :math:`f_{\text{scale,cap}}`
-     - Capital scaling factor  
-       (``Scaling > Capital Scaling Factor``)
+   * - :math:`n_{\mathrm{labor}}`
+     - Labor scaling exponent
      - Dimensionless
 
-   * - :math:`f_{\text{scale,lab}}`
-     - Labor scaling factor  
-       (``Scaling > Labor Scaling Factor``)
+   * - :math:`F_{\mathrm{cap}}`
+     - Capital scaling factor
      - Dimensionless
 
-   * - :math:`\alpha_{\text{cap}}`
-     - Capital scaling exponent  
-       (``Capital Scaling Exponent``; default = 0.78)
+   * - :math:`F_{\mathrm{labor}}`
+     - Labor scaling factor
      - Dimensionless
 
-   * - :math:`\alpha_{\text{lab}}`
-     - Labor scaling exponent  
-       (``Labor Scaling Exponent``; default = 0.25)
+   * - :math:`f_{\mathrm{op}}`
+     - Operating capacity factor
      - Dimensionless
+
+   * - :math:`Q_{\mathrm{year}}`
+     - Output per year
+     - Functional unit dimension
+
+   * - :math:`Q_{\mathrm{year,gate}}`
+     - Output per year at gate
+     - Functional unit dimension
 
 .. automodule:: pyH2A.Plugins.Production_Scaling_Plugin
     :members:

--- a/doc/plugins/Replacement_Plugin.rst
+++ b/doc/plugins/Replacement_Plugin.rst
@@ -104,7 +104,7 @@ Notation
 ~~~~~~~~
 
 .. list-table::
-   :widths: 30 50 20
+   :widths: 30 50 40
    :header-rows: 1
 
    * - Symbol
@@ -163,6 +163,8 @@ Notation
      - Inflation factor for year :math:`y`
      - dimensionless
 
+Implementation
+--------------
 
 .. automodule:: pyH2A.Plugins.Replacement_Plugin
     :members:

--- a/doc/plugins/Replacement_Plugin.rst
+++ b/doc/plugins/Replacement_Plugin.rst
@@ -1,5 +1,140 @@
 Replacement_Plugin
 ==================
 
+This plugin computes yearly replacement costs over the project lifetime, combining planned periodic replacements and unplanned replacement costs.
+
+Equations
+~~~~~~~~~
+
+Planned replacement (per component):
+
+For each component :math:`i`, with replacement frequency:
+
+.. math::
+
+   f_{\text{rep},i} = \left\lceil f_{\text{input},i} \right\rceil
+
+Non-integer frequency correction:
+
+.. math::
+
+   \kappa_i = \frac{f_{\text{rep},i}}{f_{\text{input},i}}
+
+Cost per replacement event:
+
+.. math::
+
+   C_{\text{rep},i} = C_{\text{raw},i} \cdot \kappa_i \cdot f_{\text{infl,combined}}
+
+Replacement events occur at discrete years:
+
+.. math::
+
+   t \in \{f_{\text{rep},i},\; 2 f_{\text{rep},i},\; 3 f_{\text{rep},i},\; \dots\}
+
+Yearly planned replacement cost:
+
+.. math::
+
+   C_{\text{planned}}(t) = \sum_i C_{\text{rep},i} \cdot \mathbf{1}_{t \in \text{schedule}_i}
+
+
+Unplanned replacement:
+
+.. math::
+
+   C_{\text{unplanned}} = \sum_j C_{\text{unplanned},j}
+
+This value is applied uniformly to all years:
+
+.. math::
+
+   C_{\text{unplanned}}(t) = C_{\text{unplanned}}
+
+
+Total yearly replacement cost (before final inflation factors):
+
+.. math::
+
+   C_{\text{yearly}}(t) = C_{\text{planned}}(t) + C_{\text{unplanned}}(t)
+
+
+Final inflated replacement cost:
+
+.. math::
+
+   C_{\text{replacement}}(t) = C_{\text{yearly}}(t) \cdot f_{\text{infl,correction}}(t) \cdot f_{\text{infl}}(t)
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`C_{\text{raw},i}`
+     - One-time replacement cost for component :math:`i`  
+       (``Planned Replacement > [...] > Cost``)
+     - Currency
+
+   * - :math:`f_{\text{input},i}`
+     - Replacement frequency for component :math:`i`   
+       (``Frequency``)
+     - Time
+
+   * - :math:`f_{\text{rep},i}`
+     - Effective replacement interval (rounded to integer years)
+     - Time
+
+   * - :math:`\kappa_i`
+     - Non-integer frequency correction factor
+     - Dimensionless
+
+   * - :math:`C_{\text{rep},i}`
+     - Cost per replacement event (inflated and corrected)
+     - Currency
+
+   * - :math:`C_{\text{planned}}(t)`
+     - Planned replacement cost in year :math:`t`
+     - Currency
+
+   * - :math:`C_{\text{unplanned},j}`
+     - Individual unplanned replacement cost entries  
+       (from "Unplanned Replacement" tables)
+     - Currency
+
+   * - :math:`C_{\text{unplanned}}`
+     - Total unplanned replacement cost per year
+     - Currency / time
+
+   * - :math:`C_{\text{yearly}}(t)`
+     - Total replacement cost before final inflation factors
+     - Currency
+
+   * - :math:`C_{\text{replacement}}(t)`
+     - Final yearly replacement cost (after inflation adjustments)
+     - Currency / time
+
+   * - :math:`f_{\text{infl,combined}}`
+     - Combined inflation factor (``dcf.combined_inflator``)
+     - Dimensionless
+
+   * - :math:`f_{\text{infl,correction}}(t)`
+     - Inflation correction factor over time (``dcf.inflation_correction``)
+     - Dimensionless
+
+   * - :math:`f_{\text{infl}}(t)`
+     - Time-dependent inflation factor (``dcf.inflation_factor``)
+     - Dimensionless
+
+   * - :math:`\mathbf{1}_{t \in \text{schedule}_i}`
+     - Indicator function (equals 1 when a replacement occurs at year :math:`t`, 0 otherwise)
+     - Dimensionless
+
+
 .. automodule:: pyH2A.Plugins.Replacement_Plugin
     :members:

--- a/doc/plugins/Replacement_Plugin.rst
+++ b/doc/plugins/Replacement_Plugin.rst
@@ -4,136 +4,164 @@ Replacement_Plugin
 This plugin computes yearly replacement costs over the project lifetime, combining planned periodic replacements and unplanned replacement costs.
 
 Equations
-~~~~~~~~~
+---------
 
-Planned replacement (per component):
+Planned replacement costs
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For each component :math:`i`, with replacement frequency:
-
-.. math::
-
-   f_{\text{rep},i} = \left\lceil f_{\text{input},i} \right\rceil
-
-Non-integer frequency correction:
+For each entry :math:`i` in the ``Planned Replacement`` table, the replacement frequency is converted into an integer number of years:
 
 .. math::
 
-   \kappa_i = \frac{f_{\text{rep},i}}{f_{\text{input},i}}
+   N_{\mathrm{rep},i}
+   =
+   \left\lceil
+   t_{\mathrm{rep},i}
+   \right\rceil
 
-Cost per replacement event:
+where:
 
-.. math::
+- :math:`t_{\mathrm{rep},i}` is the specified replacement frequency
+- :math:`\lceil \cdot \rceil` denotes the ceiling function
 
-   C_{\text{rep},i} = C_{\text{raw},i} \cdot \kappa_i \cdot f_{\text{infl,combined}}
-
-Replacement events occur at discrete years:
-
-.. math::
-
-   t \in \{f_{\text{rep},i},\; 2 f_{\text{rep},i},\; 3 f_{\text{rep},i},\; \dots\}
-
-Yearly planned replacement cost:
+Because replacement costs are billed annually, a correction factor is applied when the specified replacement interval is non-integer:
 
 .. math::
 
-   C_{\text{planned}}(t) = \sum_i C_{\text{rep},i} \cdot \mathbf{1}_{t \in \text{schedule}_i}
+   f_{\mathrm{noninteger},i}
+   =
+   \frac{
+   N_{\mathrm{rep},i}
+   }{
+   t_{\mathrm{rep},i}
+   }
 
-
-Unplanned replacement:
-
-.. math::
-
-   C_{\text{unplanned}} = \sum_j C_{\text{unplanned},j}
-
-This value is applied uniformly to all years:
-
-.. math::
-
-   C_{\text{unplanned}}(t) = C_{\text{unplanned}}
-
-
-Total yearly replacement cost (before final inflation factors):
+The replacement cost applied at each replacement event is then:
 
 .. math::
 
-   C_{\text{yearly}}(t) = C_{\text{planned}}(t) + C_{\text{unplanned}}(t)
+   C_{\mathrm{planned},i}
+   =
+   C_{\mathrm{raw},i}
+   \times
+   f_{\mathrm{noninteger},i}
+   \times
+   f_{\mathrm{combined}}
 
+where:
 
-Final inflated replacement cost:
+- :math:`C_{\mathrm{raw},i}` is the one-time replacement cost
+- :math:`f_{\mathrm{combined}}` is the combined inflator
+
+The yearly planned replacement cost is obtained by adding the contributions of all replacement events occurring during each project year.
+
+Unplanned replacement costs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unplanned replacement costs are obtained by summing all entries belonging to the ``Unplanned Replacement`` table group:
 
 .. math::
 
-   C_{\text{replacement}}(t) = C_{\text{yearly}}(t) \cdot f_{\text{infl,correction}}(t) \cdot f_{\text{infl}}(t)
+   C_{\mathrm{unplanned}}
+   =
+   \sum_i C_{\mathrm{unplanned},i}
+
+This value is added uniformly to each year of operation.
+
+Total yearly replacement costs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The total yearly replacement cost before inflation correction is:
+
+.. math::
+
+   C_{\mathrm{replacement}}(y)
+   =
+   C_{\mathrm{planned}}(y)
+   +
+   C_{\mathrm{unplanned}}
+
+where:
+
+- :math:`C_{\mathrm{planned}}(y)` is the total planned replacement cost during year :math:`y`
+
+The final inflated yearly replacement cost is:
+
+.. math::
+
+   C_{\mathrm{replacement}}^{\mathrm{inflated}}(y)
+   =
+   C_{\mathrm{replacement}}(y)
+   \times
+   f_{\mathrm{inflation\ correction}}(y)
+   \times
+   f_{\mathrm{inflation}}(y)
+
+The resulting quantity is stored as an array covering the entire plant lifetime.
 
 
 Notation
 ~~~~~~~~
 
 .. list-table::
+   :widths: 30 50 20
    :header-rows: 1
 
    * - Symbol
      - Description
      - Dimension
 
-   * - :math:`C_{\text{raw},i}`
-     - One-time replacement cost for component :math:`i`  
-       (``Planned Replacement > [...] > Cost``)
-     - Currency
+   * - :math:`t_{\mathrm{rep},i}`
+     - Replacement frequency for planned replacement entry :math:`i`
+     - time
 
-   * - :math:`f_{\text{input},i}`
-     - Replacement frequency for component :math:`i`   
-       (``Frequency``)
-     - Time
+   * - :math:`N_{\mathrm{rep},i}`
+     - Integer replacement interval used in the calculation
+     - time
 
-   * - :math:`f_{\text{rep},i}`
-     - Effective replacement interval (rounded to integer years)
-     - Time
+   * - :math:`f_{\mathrm{noninteger},i}`
+     - Non-integer replacement correction factor
+     - dimensionless
 
-   * - :math:`\kappa_i`
-     - Non-integer frequency correction factor
-     - Dimensionless
+   * - :math:`C_{\mathrm{raw},i}`
+     - One-time replacement cost for planned replacement entry :math:`i`
+     - currency
 
-   * - :math:`C_{\text{rep},i}`
-     - Cost per replacement event (inflated and corrected)
-     - Currency
+   * - :math:`C_{\mathrm{planned},i}`
+     - Inflated replacement cost applied at each replacement event
+     - currency
 
-   * - :math:`C_{\text{planned}}(t)`
-     - Planned replacement cost in year :math:`t`
-     - Currency
+   * - :math:`C_{\mathrm{planned}}(y)`
+     - Total planned replacement cost during year :math:`y`
+     - currency
 
-   * - :math:`C_{\text{unplanned},j}`
-     - Individual unplanned replacement cost entries  
-       (from "Unplanned Replacement" tables)
-     - Currency
+   * - :math:`C_{\mathrm{unplanned},i}`
+     - Individual unplanned replacement contribution
+     - currency
 
-   * - :math:`C_{\text{unplanned}}`
-     - Total unplanned replacement cost per year
-     - Currency / time
+   * - :math:`C_{\mathrm{unplanned}}`
+     - Total unplanned replacement cost
+     - currency
 
-   * - :math:`C_{\text{yearly}}(t)`
-     - Total replacement cost before final inflation factors
-     - Currency
+   * - :math:`C_{\mathrm{replacement}}(y)`
+     - Total yearly replacement cost before inflation correction
+     - currency
 
-   * - :math:`C_{\text{replacement}}(t)`
-     - Final yearly replacement cost (after inflation adjustments)
-     - Currency / time
+   * - :math:`C_{\mathrm{replacement}}^{\mathrm{inflated}}(y)`
+     - Total yearly inflated replacement cost
+     - currency
 
-   * - :math:`f_{\text{infl,combined}}`
-     - Combined inflation factor (``dcf.combined_inflator``)
-     - Dimensionless
+   * - :math:`f_{\mathrm{combined}}`
+     - Combined inflator
+     - dimensionless
 
-   * - :math:`f_{\text{infl,correction}}(t)`
-     - Inflation correction factor over time (``dcf.inflation_correction``)
-     - Dimensionless
+   * - :math:`f_{\mathrm{inflation\ correction}}(y)`
+     - Inflation correction factor for year :math:`y`
+     - dimensionless
 
-   * - :math:`f_{\text{infl}}(t)`
-     - Time-dependent inflation factor (``dcf.inflation_factor``)
-     - Dimensionless
-
-   * - :math:`\mathbf{1}_{t \in \text{schedule}_i}`
-     - Indicator function (equals 1 when a replacement occurs at year :math:`t`, 0 otherwise)
-     - Dimensionless
+   * - :math:`f_{\mathrm{inflation}}(y)`
+     - Inflation factor for year :math:`y`
+     - dimensionless
 
 
 .. automodule:: pyH2A.Plugins.Replacement_Plugin

--- a/doc/plugins/Reverse_Osmosis_Plugin.rst
+++ b/doc/plugins/Reverse_Osmosis_Plugin.rst
@@ -1,5 +1,129 @@
 Reverse_Osmosis_Plugin
-===================
+======================
+
+Equations
+---------
+
+Fresh water requirement from hydrogen production
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The hydrogen output is first converted into a required freshwater mass using stoichiometry:
+
+.. math::
+
+   m_{\mathrm{H2O},y}
+   =
+   m_{\mathrm{H2},y}
+   \cdot
+   \frac{M_{\mathrm{H2O}}}{M_{\mathrm{H2}}}
+
+Fresh water volume demand:
+
+.. math::
+
+   V_{\mathrm{fresh},y}
+   =
+   \frac{m_{\mathrm{H2O},y}}{\rho_{\mathrm{water}}}
+
+Sea water demand corrected for recovery rate:
+
+.. math::
+
+   V_{\mathrm{sea},y}
+   =
+   \frac{V_{\mathrm{fresh},y}}{\eta_{\mathrm{rec}}}
+
+
+Electricity demand of reverse osmosis:
+
+.. math::
+
+   E_{\mathrm{RO},y}
+   =
+   V_{\mathrm{sea},y}
+   \cdot
+   e_{\mathrm{RO}}
+
+Construction delay is applied by truncating the time series:
+
+.. math::
+
+   E_{\mathrm{RO},y}^{\mathrm{effective}}
+   =
+   E_{\mathrm{RO},y}
+   \big[\, t \geq t_{\mathrm{construction}} \,\big]
+
+Maximum sea water processing flowrate:
+
+.. math::
+
+   \dot{V}_{\mathrm{sea}}^{\max}
+   =
+   \frac{\max_y(V_{\mathrm{sea},y})}{H_{\mathrm{year}} \cdot f_{\mathrm{op}}}
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`m_{\mathrm{H2},y}`
+     - Hydrogen production in year y
+     - mass
+
+   * - :math:`M_{\mathrm{H2O}}, M_{\mathrm{H2}}`
+     - Molar masses of water and hydrogen
+     - mass/substance
+
+   * - :math:`\rho_{\mathrm{water}}`
+     - Density of water
+     - mass/volume
+
+   * - :math:`V_{\mathrm{fresh},y}`
+     - Fresh water demand
+     - volume
+
+   * - :math:`\eta_{\mathrm{rec}}`
+     - Reverse osmosis recovery rate
+     - dimensionless
+
+   * - :math:`V_{\mathrm{sea},y}`
+     - Sea water intake volume
+     - volume
+
+   * - :math:`e_{\mathrm{RO}}`
+     - Reverse osmosis energy demand per volume
+     - energy/volume
+
+   * - :math:`E_{\mathrm{RO},y}`
+     - Electricity demand of RO system (before construction delay)
+     - energy
+
+   * - :math:`t_{\mathrm{construction}}`
+     - Construction time
+     - time
+
+   * - :math:`f_{\mathrm{op}}`
+     - Average operating time fraction
+     - dimensionless
+
+   * - :math:`H_{\mathrm{year}}`
+     - Hours in a year
+     - time
+
+   * - :math:`\dot{V}_{\mathrm{sea}}^{\max}`
+     - Maximum seawater processing flowrate
+     - volume/time      
+
+
+
+Implementation
+--------------
 
 .. automodule:: pyH2A.Plugins.Reverse_Osmosis_Plugin
     :members:

--- a/doc/plugins/Reverse_Osmosis_Plugin.rst
+++ b/doc/plugins/Reverse_Osmosis_Plugin.rst
@@ -1,0 +1,5 @@
+Reverse_Osmosis_Plugin
+===================
+
+.. automodule:: pyH2A.Plugins.Reverse_Osmosis_Plugin
+    :members:

--- a/doc/plugins/Solar_Concentrator_Plugin.rst
+++ b/doc/plugins/Solar_Concentrator_Plugin.rst
@@ -1,5 +1,155 @@
 Solar_Concentrator_Plugin
 =========================
 
+
+
+Equations
+---------
+
+Solar concentration scales the active collection area and propagates into land use and capital cost.
+
+Solar collection area
+~~~~~~~~~~~~~~~~~~~~~~
+
+The concentrated solar collection area is:
+
+.. math::
+
+   A_{\mathrm{solar}}
+   =
+   f_{\mathrm{conc}} \cdot A_{\mathrm{solar,0}}
+
+
+Area per PEC element
+~~~~~~~~~~~~~~~~~~~~~
+
+The area assigned per PEC cell is:
+
+.. math::
+
+   A_{\mathrm{cell}}
+   =
+   \frac{A_{\mathrm{solar}}}{N_{\mathrm{PEC}}}
+
+
+A characteristic side length is derived as:
+
+.. math::
+
+   L_{\mathrm{cell}} = \sqrt{A_{\mathrm{cell}}}
+
+
+
+Spacing correction (land footprint)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Including spacing in both directions:
+
+.. math::
+
+   L_x = L_{\mathrm{cell}} + \frac{s_{EW}}{2}
+
+.. math::
+
+   L_y = L_{\mathrm{cell}} + \frac{s_{S}}{2}
+
+where:
+- :math:`s_{EW}` = east-west spacing  
+- :math:`s_{S}` = south spacing  
+
+The spaced area per element becomes:
+
+.. math::
+
+   A_{\mathrm{land,cell}} = L_x \cdot L_y
+
+Total land area:
+
+.. math::
+
+   A_{\mathrm{land}}
+   =
+   N_{\mathrm{PEC}} \cdot A_{\mathrm{land,cell}}
+
+
+
+Solar concentrator capital cost
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The total concentrator cost is:
+
+.. math::
+
+   C_{\mathrm{conc,tot}}
+   =
+   c_{\mathrm{conc}} \cdot A_{\mathrm{solar}}
+
+where:
+- :math:`c_{\mathrm{conc}}` is cost per unit area
+- :math:`A_{\mathrm{solar}}` is total solar collection area
+
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`f_{\mathrm{conc}}`
+     - Solar concentration factor
+     - dimensionless
+
+   * - :math:`A_{\mathrm{solar,0}}`
+     - Unconcentrated solar collection area
+       (input solar collection area)
+     - area
+
+   * - :math:`A_{\mathrm{solar}}`
+     - Concentrated solar collection area
+     - area
+
+   * - :math:`N_{\mathrm{PEC}}`
+     - Number of PEC cells
+     - dimensionless
+
+   * - :math:`A_{\mathrm{cell}}`
+     - Area allocated per PEC cell
+     - area
+
+   * - :math:`L_{\mathrm{cell}}`
+     - Characteristic linear dimension per PEC cell
+     - length
+
+   * - :math:`s_S`
+     - South spacing
+     - length
+
+   * - :math:`s_{EW}`
+     - East/West spacing
+     - length
+
+   * - :math:`A_{\mathrm{land}}`
+     - Total land area requirement
+     - area
+
+   * - :math:`c_{\mathrm{conc}}`
+     - Solar concentrator cost per area
+     - currency / area
+
+   * - :math:`C_{\mathrm{conc,tot}}`
+     - Total solar concentrator capital cost
+     - currency
+
+
+Implementation
+--------------
+
+
 .. automodule:: pyH2A.Plugins.Solar_Concentrator_Plugin
     :members:

--- a/doc/plugins/Solar_Thermal_Plugin.rst
+++ b/doc/plugins/Solar_Thermal_Plugin.rst
@@ -1,5 +1,127 @@
 Solar_Thermal_Plugin
 ====================
 
+The plugin estimates the required land area for thermochemical hydrogen production using solar input, conversion efficiency, and production target.
+
+Equations
+---------
+
+
+Solar-to-hydrogen conversion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The molar production rate per unit area is:
+
+.. math::
+
+   \dot{n}_{\mathrm{H_2}}
+   =
+   \frac{I_{\mathrm{solar}} \cdot \eta_{\mathrm{STH}}}
+   {E_{\mathrm{H_2}}}
+
+where:
+
+- :math:`I_{\mathrm{solar}}` is the mean solar input,
+- :math:`\eta_{\mathrm{STH}}` is the solar-to-hydrogen efficiency,
+- :math:`E_{\mathrm{H_2}}` is the energy required per mole of hydrogen.
+
+Conversion to mass-based production
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The hydrogen mass production per unit area is:
+
+.. math::
+
+   \dot{m}_{\mathrm{H_2}}
+   =
+   \dot{n}_{\mathrm{H_2}} \cdot M_{\mathrm{H_2}}
+
+where :math:`M_{\mathrm{H_2}}` is the molar mass of hydrogen.
+
+For alternative functional units (e.g. hydrogen peroxide), a fixed stoichiometric scaling is applied:
+
+.. math::
+
+   \dot{m}_{\mathrm{H_2O_2}}
+   =
+   17 \cdot \dot{m}_{\mathrm{H_2}}
+
+Required land area
+~~~~~~~~~~~~~~~~~~
+
+The required solar collection area is computed from the plant design output rate:
+
+.. math::
+
+   A_{\mathrm{req}}
+   =
+   \frac{\dot{m}_{\mathrm{design}}}{\dot{m}_{\mathrm{H_2}}}
+
+The final land requirement includes an additional land area factor:
+
+.. math::
+
+   A_{\mathrm{total}}
+   =
+   A_{\mathrm{req}} \cdot (1 + f_{\mathrm{land,add}})
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 50 30
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`I_{\mathrm{solar}}`
+     - Mean solar input
+     - power / area
+
+   * - :math:`\eta_{\mathrm{STH}}`
+     - Solar-to-hydrogen efficiency
+     - Dimensionless
+
+   * - :math:`E_{\mathrm{H_2}}`
+     - Energy per mole of hydrogen
+     - energy / mole
+
+   * - :math:`\dot{n}_{\mathrm{H_2}}`
+     - Hydrogen molar production rate per area
+     - mol / (area · time)
+
+   * - :math:`M_{\mathrm{H_2}}`
+     - Molar mass of hydrogen
+     - kg / mol
+
+   * - :math:`\dot{m}_{\mathrm{H_2}}`
+     - Hydrogen mass production per area
+     - mass / (area · time)
+
+   * - :math:`\dot{m}_{\mathrm{H_2O_2}}`
+     - Equivalent hydrogen peroxide mass rate
+     - mass / (area · time)
+
+   * - :math:`\dot{m}_{\mathrm{design}}`
+     - Plant design output rate
+     - mass / time
+
+   * - :math:`A_{\mathrm{req}}`
+     - Required solar collection area
+     - area
+
+   * - :math:`f_{\mathrm{land,add}}`
+     - Additional land area factor
+     - Dimensionless
+
+   * - :math:`A_{\mathrm{total}}`
+     - Total required land area
+     - area
+
+Implementation
+--------------
+
 .. automodule:: pyH2A.Plugins.Solar_Thermal_Plugin
     :members:

--- a/doc/plugins/Stored_Power_Electrolysis_Plugin.rst
+++ b/doc/plugins/Stored_Power_Electrolysis_Plugin.rst
@@ -1,0 +1,5 @@
+Stored_Power_Electrolysis_Plugin
+================================
+
+.. automodule:: pyH2A.Plugins.Stored_Power_Electrolysis_Plugin
+    :members:

--- a/doc/plugins/Stored_Power_Electrolysis_Plugin.rst
+++ b/doc/plugins/Stored_Power_Electrolysis_Plugin.rst
@@ -1,5 +1,193 @@
 Stored_Power_Electrolysis_Plugin
 ================================
 
+This plugin computes hydrogen production from stored-energy electrolysis, tracks annual energy consumption, and determines stack replacement frequency.
+
+Equations
+---------
+
+
+Electrolyzer power demand
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The electrolyzer power demand increases over time due to degradation:
+
+.. math::
+
+   P_{\mathrm{ely}}(t)
+   =
+   P_{\mathrm{nom}}
+   \cdot (1 + r_{\mathrm{deg}})^{t}
+
+where the degradation factor is:
+
+.. math::
+
+   I_{\mathrm{deg}}(t) = (1 + r_{\mathrm{deg}})^{t}
+
+Maximum usable energy per year
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The maximum energy that can be consumed by the electrolyzer is limited by operating time:
+
+.. math::
+
+   E_{\mathrm{max}}(t)
+   =
+   \left(T_{\mathrm{year}} - T_{\mathrm{op}}(t)\right)
+   \cdot P_{\mathrm{ely}}(t)
+
+Available stored energy
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Stored energy available for electrolysis is:
+
+.. math::
+
+   E_{\mathrm{store,avail}}(t)
+   =
+   f_{\mathrm{store}} \cdot E_{\mathrm{store}}(t)
+
+Energy consumption (actual)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Actual electrolysis energy consumption is the minimum of available storage and demand:
+
+.. math::
+
+   E_{\mathrm{cons}}(t)
+   =
+   \min \left(
+   E_{\mathrm{max}}(t),
+   E_{\mathrm{store,avail}}(t)
+   \right)
+
+Hydrogen production
+~~~~~~~~~~~~~~~~~~~
+
+Hydrogen production is computed from energy consumption and conversion efficiency:
+
+.. math::
+
+   \dot{m}_{\mathrm{H2}}(t)
+   =
+   \frac{E_{\mathrm{cons}}(t) \cdot \eta_{\mathrm{ely}}}
+   {I_{\mathrm{deg}}(t)}
+
+Stack replacement frequency
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The cumulative operating time determines stack replacement timing:
+
+.. math::
+
+   T_{\mathrm{cum}}(t) = \sum_{i \le t} T_{\mathrm{op}}(i)
+
+.. math::
+
+   N_{\mathrm{rep}} = \left\lfloor \frac{T_{\mathrm{cum}}(T)}{T_{\mathrm{rep}}} \right\rfloor
+
+.. math::
+
+   f_{\mathrm{rep}} =
+   \frac{N_{\mathrm{years}}}{N_{\mathrm{rep}} + 1}
+
+Updated annual hydrogen production
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Final hydrogen production includes degradation-adjusted additional production:
+
+.. math::
+
+   \dot{m}_{\mathrm{H2,new}}(t)
+   =
+   \dot{m}_{\mathrm{H2,old}}(t)
+   +
+   \Delta \dot{m}_{\mathrm{H2}}(t)
+
+where:
+
+.. math::
+
+   \Delta \dot{m}_{\mathrm{H2}}(t)
+   =
+   \frac{E_{\mathrm{cons}}(t) \cdot \eta_{\mathrm{ely}}}
+   {I_{\mathrm{deg}}(t)}
+
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50 20
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`f_{\mathrm{store}}`
+     - Fraction of stored power used for electrolysis
+     - Dimensionless
+
+   * - :math:`E_{\mathrm{store}}(t)`
+     - Stored energy available per year
+     - Energy
+
+   * - :math:`E_{\mathrm{cons}}(t)`
+     - Electrolysis energy consumption
+     - Energy
+
+   * - :math:`E_{\mathrm{max}}(t)`
+     - Maximum consumable energy
+     - Energy
+
+   * - :math:`P_{\mathrm{ely}}(t)`
+     - Electrolyzer power demand
+     - Power
+
+   * - :math:`P_{\mathrm{nom}}`
+     - Nominal electrolyzer power
+     - Power
+
+   * - :math:`r_{\mathrm{deg}}`
+     - Power requirement increase per year
+     - Dimensionless
+
+   * - :math:`I_{\mathrm{deg}}(t)`
+     - Degradation/increase factor
+     - Dimensionless
+
+   * - :math:`\eta_{\mathrm{ely}}`
+     - Hydrogen yield per unit energy
+     - mass / energy
+
+   * - :math:`\dot{m}_{\mathrm{H2}}(t)`
+     - Hydrogen production rate (yearly)
+     - mass / time
+
+   * - :math:`T_{\mathrm{op}}(t)`
+     - Operating time per year
+     - time
+
+   * - :math:`T_{\mathrm{rep}}`
+     - Stack replacement time
+     - time
+
+   * - :math:`f_{\mathrm{rep}}`
+     - Replacement frequency (years)
+     - time
+
+   * - :math:`\dot{m}_{\mathrm{H2,new}}(t)`
+     - Updated hydrogen production
+     - mass / time
+
+
+Implementation
+--------------
+
+
+
 .. automodule:: pyH2A.Plugins.Stored_Power_Electrolysis_Plugin
     :members:

--- a/doc/plugins/Variable_Operating_Cost_Plugin.rst
+++ b/doc/plugins/Variable_Operating_Cost_Plugin.rst
@@ -1,5 +1,120 @@
 Variable_Operating_Cost_Plugin
 ==============================
 
+This plugin computes variable operating costs, including utility costs (time-dependent) and other variable costs.
+The result is expressed as a time-dependent quantity (array over plant lifetime).
+
+Equations
+~~~~~~~~~
+
+Utility cost per kg of hydrogen (for each utility :math:`u`):
+
+.. math::
+
+   c_{\text{util},u}(t) = p_u(t) \cdot f_{\text{infl}}(t) \cdot f_{\text{conv},u} \cdot \gamma_u
+
+Total utility cost per kg of hydrogen:
+
+.. math::
+
+   c_{\text{util,total}}(t) = \sum_u c_{\text{util},u}(t)
+
+
+Total utility cost per year:
+
+.. math::
+
+   C_{\text{util}}(t) = c_{\text{util,total}}(t) \cdot Q_{\text{year}}
+
+
+Other variable operating costs:
+
+.. math::
+
+   C_{\text{var,other}} = \left( \sum_i C_{\text{var,other},i} \right) \cdot f_{\text{infl,chem}}
+
+
+Total variable operating costs:
+
+.. math::
+
+   C_{\text{var,total}}(t) = C_{\text{util}}(t) + C_{\text{var,other}}
+
+
+Notation
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Symbol
+     - Description
+     - Dimension
+
+   * - :math:`p_u(t)`
+     - Cost of utility :math:`u` (possibly time-dependent, from file or scalar)  
+       (``Utilities > [...] > Cost``)
+     - Currency / utility amount
+
+   * - :math:`\gamma_u`
+     - Utility usage per kg of hydrogen  
+       (``Utilities > [...] > Usage per kg H2``)
+     - Utility amount / mass
+
+   * - :math:`f_{\text{conv},u}`
+     - Price conversion factor  
+       (``Utilities > [...] > Price Conversion Factor``)
+     - Dimensionless
+
+   * - :math:`f_{\text{infl}}(t)`
+     - Inflation correction factor over time (``dcf.inflation_correction``)
+     - Dimensionless
+
+   * - :math:`c_{\text{util},u}(t)`
+     - Cost contribution of utility :math:`u` per kg of hydrogen
+     - Currency / mass
+
+   * - :math:`c_{\text{util,total}}(t)`
+     - Total utility cost per kg of hydrogen
+     - Currency / mass
+
+   * - :math:`Q_{\text{year}}`
+     - Yearly hydrogen production  
+       (``Output per Year``)
+     - Mass
+
+   * - :math:`C_{\text{util}}(t)`
+     - Total utility cost per year (time-dependent)
+     - Currency / time
+
+   * - :math:`C_{\text{var,other},i}`
+     - Individual other variable operating cost entries  
+       (from "Other Variable Operating Cost" tables)
+     - Currency
+
+   * - :math:`C_{\text{var,other}}`
+     - Total other variable operating costs (after inflation)
+     - Currency
+
+   * - :math:`f_{\text{infl,chem}}`
+     - Chemical inflation factor (``dcf.chemical_inflator``)
+     - Dimensionless
+
+   * - :math:`C_{\text{var,total}}(t)`
+     - Total variable operating costs (time-dependent)
+     - Currency
+
+
+Notes
+-----
+
+- Utility costs are evaluated **per kg of hydrogen**, then scaled by annual production.
+- Costs can be:
+  - constant (scalar),
+  - time-dependent (array),
+  - or read from external files.
+- Inflation correction is applied at the **unit cost level**.
+- Other variable operating costs are aggregated using ``sum_all_tables()`` and scaled by the chemical inflator.
+
 .. automodule:: pyH2A.Plugins.Variable_Operating_Cost_Plugin
     :members:

--- a/doc/plugins/Variable_Operating_Cost_Plugin.rst
+++ b/doc/plugins/Variable_Operating_Cost_Plugin.rst
@@ -74,7 +74,7 @@ Notation
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 50 20
+   :widths: 30 50 50
 
    * - Symbol
      - Description
@@ -134,6 +134,9 @@ Notes
   - or read from external files.
 - Inflation correction is applied at the **unit cost level**.
 - Other variable operating costs are aggregated using ``sum_all_tables()`` and scaled by the chemical inflator.
+
+Implementation
+--------------
 
 .. automodule:: pyH2A.Plugins.Variable_Operating_Cost_Plugin
     :members:

--- a/doc/plugins/Variable_Operating_Cost_Plugin.rst
+++ b/doc/plugins/Variable_Operating_Cost_Plugin.rst
@@ -5,110 +5,129 @@ This plugin computes variable operating costs, including utility costs (time-dep
 The result is expressed as a time-dependent quantity (array over plant lifetime).
 
 Equations
-~~~~~~~~~
+---------
 
-Utility cost per kg of hydrogen (for each utility :math:`u`):
+Utility costs
+~~~~~~~~~~~~~
 
-.. math::
-
-   c_{\text{util},u}(t) = p_u(t) \cdot f_{\text{infl}}(t) \cdot f_{\text{conv},u} \cdot \gamma_u
-
-Total utility cost per kg of hydrogen:
+For each utility :math:`i`, the cost per functional unit is calculated as:
 
 .. math::
 
-   c_{\text{util,total}}(t) = \sum_u c_{\text{util},u}(t)
+   C_{\mathrm{util},i}^{\mathrm{FU}}
+   =
+   P_i
+   \times
+   U_i
+   \times
+   F_{\mathrm{conv},i}
+   \times
+   f_{\mathrm{inflation}}
 
+where the utility price may be either:
 
-Total utility cost per year:
+- A scalar value,
+- A yearly array,
+- Or a time-dependent value read from an external text file.
+
+The total utility operating cost is then:
 
 .. math::
 
-   C_{\text{util}}(t) = c_{\text{util,total}}(t) \cdot Q_{\text{year}}
+   C_{\mathrm{utilities}}
+   =
+   Q_{\mathrm{year}}
+   \times
+   \sum_i
+   C_{\mathrm{util},i}^{\mathrm{FU}}
 
+Other variable operating costs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Other variable operating costs:
+Other variable operating cost contributions are summed across all tables belonging to the
+``Other Variable Operating Cost`` group:
 
 .. math::
 
-   C_{\text{var,other}} = \left( \sum_i C_{\text{var,other},i} \right) \cdot f_{\text{infl,chem}}
+   C_{\mathrm{other}}
+   =
+   f_{\mathrm{chem}}
+   \times
+   \sum_j
+   C_{\mathrm{other},j}
 
+Total variable operating costs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Total variable operating costs:
+The total variable operating cost is:
 
 .. math::
 
-   C_{\text{var,total}}(t) = C_{\text{util}}(t) + C_{\text{var,other}}
-
+   C_{\mathrm{var,total}}
+   =
+   C_{\mathrm{utilities}}
+   +
+   C_{\mathrm{other}}
 
 Notation
 ~~~~~~~~
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 50 20
 
    * - Symbol
      - Description
      - Dimension
 
-   * - :math:`p_u(t)`
-     - Cost of utility :math:`u` (possibly time-dependent, from file or scalar)  
-       (``Utilities > [...] > Cost``)
-     - Currency / utility amount
-
-   * - :math:`\gamma_u`
-     - Utility usage per kg of hydrogen  
-       (``Utilities > [...] > Usage per kg H2``)
-     - Utility amount / mass
-
-   * - :math:`f_{\text{conv},u}`
-     - Price conversion factor  
-       (``Utilities > [...] > Price Conversion Factor``)
-     - Dimensionless
-
-   * - :math:`f_{\text{infl}}(t)`
-     - Inflation correction factor over time (``dcf.inflation_correction``)
-     - Dimensionless
-
-   * - :math:`c_{\text{util},u}(t)`
-     - Cost contribution of utility :math:`u` per kg of hydrogen
-     - Currency / mass
-
-   * - :math:`c_{\text{util,total}}(t)`
-     - Total utility cost per kg of hydrogen
-     - Currency / mass
-
-   * - :math:`Q_{\text{year}}`
-     - Yearly hydrogen production  
-       (``Output per Year``)
-     - Mass
-
-   * - :math:`C_{\text{util}}(t)`
-     - Total utility cost per year (time-dependent)
-     - Currency / time
-
-   * - :math:`C_{\text{var,other},i}`
-     - Individual other variable operating cost entries  
-       (from "Other Variable Operating Cost" tables)
+   * - :math:`P_i`
+     - Utility cost for utility :math:`i`
      - Currency
 
-   * - :math:`C_{\text{var,other}}`
-     - Total other variable operating costs (after inflation)
-     - Currency
+   * - :math:`U_i`
+     - Utility usage per functional unit for utility :math:`i`
+     - 1 / Functional unit dimension
 
-   * - :math:`f_{\text{infl,chem}}`
-     - Chemical inflation factor (``dcf.chemical_inflator``)
+   * - :math:`F_{\mathrm{conv},i}`
+     - Price conversion factor for utility :math:`i`
      - Dimensionless
 
-   * - :math:`C_{\text{var,total}}(t)`
-     - Total variable operating costs (time-dependent)
+   * - :math:`f_{\mathrm{inflation}}`
+     - Inflation correction factor
+     - Dimensionless
+
+   * - :math:`C_{\mathrm{util},i}^{\mathrm{FU}}`
+     - Inflation-corrected utility cost per functional unit
+     - currency / Functional unit dimension
+
+   * - :math:`Q_{\mathrm{year}}`
+     - Output per year
+     - Functional unit dimension
+
+   * - :math:`C_{\mathrm{utilities}}`
+     - Total utility operating costs
      - Currency
 
+   * - :math:`C_{\mathrm{other},j}`
+     - Individual other variable operating cost contribution
+     - Currency
+
+   * - :math:`f_{\mathrm{chem}}`
+     - Chemical inflator
+     - Dimensionless
+
+   * - :math:`C_{\mathrm{other}}`
+     - Total other variable operating costs
+     - Currency
+
+   * - :math:`C_{\mathrm{var,total}}`
+     - Total variable operating costs
+     - Currency
 
 Notes
 -----
 
-- Utility costs are evaluated **per kg of hydrogen**, then scaled by annual production.
+- Utility costs are evaluated **per functional unit**, then scaled by annual delivered units.
 - Costs can be:
   - constant (scalar),
   - time-dependent (array),

--- a/doc/plugins/plugins.rst
+++ b/doc/plugins/plugins.rst
@@ -1,3 +1,5 @@
+.. _plugins:
+
 Plugins
 =======
 

--- a/doc/plugins/plugins.rst
+++ b/doc/plugins/plugins.rst
@@ -1,5 +1,3 @@
-.. _plugins:
-
 Plugins
 =======
 
@@ -10,17 +8,22 @@ Plugins allow for modelling of different hydrogen production pathways. They proc
    :caption: Plugins
 
    Plugin_Guide
+   Battery_Plugin
    Capital_Cost_Plugin
    Catalyst_Separation_Plugin
+   Electrolyzer_Plugin
    Fixed_Operating_Cost_Plugin
    Hourly_Irradiation_Plugin
    Multiple_Modules_Plugin
    PEC_Plugin
    Photocatalytic_Plugin
    Photovoltaic_Plugin
+   Power_Management_Plugin
    Production_Scaling_Plugin
    Replacement_Plugin
+   Reverse_Osmosis_Plugin
    Solar_Concentrator_Plugin
    Solar_Thermal_Plugin
+   Stored_Power_Electrolysis_Plugin
    Variable_Operating_Cost_Plugin
 


### PR DESCRIPTION
# Preliminary note:
These elements of documentation are not dedicated to advanced users: the goal is to give a first understanding of the general pyH2A logic to people who discover the tool. 
The key word here is: **hierarchization** of the information, to prioritize what new users need to understand before they can later go into details. That's the difficulty when writing the documentation: finding the correct balance in order to be informative _yet_ simple enough, so users can actually get the take home message:
- some simplifications are necessary: some stuff might not me rigorously true in some cases, but constitute a good first approximation.
- We want to keep these pages short. Writing the equivalent of 100 printed pages would be counter-productive, as it would drown users into indigestible details. If we want comprehensiveness and accuracy, that should be the point of separate pages (it's already partly the case: the 'overview' and 'dictionary_structure' pages point to more detailed pages about IO resolver, about plugins...).
- Guiding explicitely users is essential, whether in terms of navigation in the various folders, in terms of the correspondance between plain english/math and code implementation, or in terms of naming etc (e.g. "input_modification" could raise the expectation that it only handles inputs: it's important to mention briefly that this refers to the modification of dcf.inp, which includes insert function as well for example ; in the same way, a new user can be confused about what we call "Utilities" in the folder structure, etc)

# Description

Add three kind of elements to the documentation:
- "Overview" page, which describes the navigation in the folders structure (with brief description of the logic of the folders and files), followed by a general explanation of pyH2A calculation rationale (including the plugin workflow, distinguishing the "core" default calculation from the situation-specific plugins)
- "dictionary structure" page, explaining how dcf.inp is created / processed / updated in plugins, including the path-based multiplication, the possibility tor efer to existing variables in a table of the input file, etc
- Plain math descriptions of the plugins. Basically: without looking at the python code, we want to be able to see what calculations are made.


# Motivation / Background
- Target users are not necessarily advanced Python developers: they need to be guided from a plain english/plain math description to an implementation in the code.
- Even for people who are proficient in Python, reverse engineering the code is time-consuming, error-prone, and, ultimately, can deter potential users.



# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [X] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change

# How Has This Been Tested?
NA

# Checklist
- [ ] Code follows pyH2A style guidelines
- [ ] Self-review of code completed
- [ ] Comments added in complex or critical sections
- [X] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [ ] No new warnings generated
- [ ] Tests added / updated and passing
- [ ] Dependent changes merged and published
