### PR TITLE
Fix: sum_tables to work with Quantity objects, integration into input_resolver

### DIFF
--- a/src/pyH2A/Plugins/Test_Plugin_A.py
+++ b/src/pyH2A/Plugins/Test_Plugin_A.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from pyH2A.Utilities.input_modification import sum_all_tables_quantity
 from pyH2A.Utilities.IO import input_resolver_function, output_inserter_function
 from pyH2A.Utilities.Unit_Handler import Quantity
 
@@ -15,7 +16,77 @@ input_dict = {
             },
             'description': 'Power Test Value'
         }
-    } 
+    },
+    '<...> Sum Testing <...>': {
+        '<...>': {
+            'Value': {
+                'type': {float, int},
+                'bounds': (0, None),
+                'path': 'Sum Path'
+            },
+            'Unit': {
+                'dimension': 'currency'
+            },
+            'optional': True,
+            'description': 'Sum Test Value'
+        },
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed Total',
+                'middle_key_total_group_insertion': 'Summed Group Total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },
+    },
+    '<...> Indirect Testing <...>': {
+        '<...>': {
+            'Value': {
+                'type': {float, int},
+                'bounds': (0, None),
+                'path': 'Path'
+            },
+            'Unit': {
+                'dimension': 'currency'
+            },
+            'optional': True,
+            'description': 'Indirect Test Value'
+        },
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed Total',
+                'middle_key_total_group_insertion': 'Summed Group Total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },
+    },
+    'Individual Table Sum': {
+        '<...>': {
+            'Value': {
+                'type': {float, int},
+                'bounds': (0, None),
+                'path': 'Path'
+            },
+            'Unit': {
+                'dimension': 'currency'
+            },
+            'optional': True,
+            'description': 'Individual Table Sum Test Value'
+        },
+        'sum_tables': {
+            'mode': 'single',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed Total',
+                'bottom_key_insertion': 'Value'
+            }
+        }
+    }
 }
 
 output_dict = {
@@ -28,9 +99,80 @@ output_dict = {
             },
             'description': 'Calculated energy'
         }
-    }
+    },
+    'special_insertions': {
+        'sum_all_tables': {
+            '<...> Sum Testing <...>': {
+                'Summed Total': {
+                    'Value': {
+                        'type': {float, int},
+                        'dimension': 'currency',
+                    },
+                    'description': 'Sum of table values'
+                },
+            },
+            'Sum Testing': {
+                'Summed Total': {
+                    'Value': {
+                        'type': {float, int},
+                        'dimension': 'currency',        
+                    },
+                    'optional': True,
+                    'description': 'Sum of table values'
+                },
+                'Summed Group Total': {
+                    'Value': {
+                        'type': {float, int},
+                        'dimension': 'currency',
+                    },
+                    'optional': False,
+                    'description': 'Sum of all values in table group "Sum Testing"'
+                },
+                'Contributions': {
+                    'Value': {
+                        'type': {dict},
+                        'dimension': 'currency',
+                    },
+                    'description': 'Contributions to the sum'
+                },
+            },
+            '<...> Indirect Testing <...>': {
+                'Summed Total': {
+                    'Value': {
+                        'type': {float, int},
+                        'dimension': 'currency',
+                    },
+                    'description': 'Sum of all values in table group "Indirect Testing"'
+                }
+            },
+            'Indirect Testing': {
+                'Summed Group Total': {
+                    'Value': {
+                        'type': {float, int},
+                        'dimension': 'currency'
+                    },
+                    'description': 'Sum of all values in table group "Indirect Testing"'
+                },
+                'Contributions': {
+                    'Value': {
+                        'type': {dict},
+                        'dimension': 'currency',
+                    },
+                    'description': 'Contributions to the sum'
+                },
+            },
+            'Individual Table Sum': {
+                'Summed Total': {
+                    'Value': {
+                        'type': {float, int},
+                        'dimension': 'currency'
+                    },
+                    'description': 'Sum of all values in this table'
+                }
+            }
+        }
+    } 
 }
-
 
 class Test_Plugin_A:
 

--- a/src/pyH2A/Utilities/IO/input_resolver.py
+++ b/src/pyH2A/Utilities/IO/input_resolver.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from pyH2A.Utilities.check_functions import check_type, check_if_in_options, check_dimension, check_bounds
 from pyH2A.Utilities.Unit_Handler.quantity import Quantity
-from pyH2A.Utilities.input_modification import process_input
+from pyH2A.Utilities.input_modification import process_input, sum_table_quantity, sum_all_tables_quantity
 
 from tests.Utilities.Input_Resolver.input_resolver_test_data import DummyDCF, input_dict, input_dict_resolved
 
@@ -11,8 +11,14 @@ from tests.Utilities.Input_Resolver.input_resolver_test_data import DummyDCF, in
 # It is used to indicate that the number of tables/rows is flexible and can be determined based on the content of dcf_class.inp
 WILDCARD_MARKER = "<...>"
 
+# Special middle keys 
+SPECIAL_MIDDLE_KEYS = ['sum_tables']
+
 # These keys are not considered when constructing the resolved values 
 SPECIAL_BOTTOM_KEYS = ['description', 'optional']
+
+# Sum tables key
+SUM_TABLES_KEY = 'sum_tables'
 
 # Key indicating if a value is optional or not
 OPTIONAL_KEY = 'optional'
@@ -407,18 +413,41 @@ def table_resolver_function(top_key, table_dict, dcf_class):
     resolved_table = {}
 
     for middle_key, row_dict in table_dict.items():
+
+        # Skip special middle keys
+        if middle_key in SPECIAL_MIDDLE_KEYS:
+            continue
+
         # Check if middle_key indicates wildcard row (flexible number of rows, middle_key is only placeholder), 
         # if so call wildcard row resolver function
         if WILDCARD_MARKER in middle_key:
             resolved_rows = wildcard_row_resolver_function(top_key, row_dict, dcf_class)
             resolved_table.update(resolved_rows)
-        
+
         # If not, resolve row as normal
         else:
             resolved_row = row_resolver_function(top_key, middle_key, row_dict, dcf_class)
 
             if resolved_row is not None:
                 resolved_table[middle_key] = resolved_row
+
+    # Handle sum tables if specified in table_dict (sum of values across multiple tables, 
+    # with specifications provided in table_dict under middle key SUM_TABLES_KEY)
+    if SUM_TABLES_KEY in table_dict:
+
+        sum_table_arguments = dict(table_dict[SUM_TABLES_KEY]['arguments'])
+        sum_table_arguments.pop('middle_key_contributions_insertion', None)
+        sum_table_arguments.pop('middle_key_total_group_insertion', None)
+
+        table_sum = sum_table_quantity(
+            dictionary = {top_key: resolved_table},
+            top_key = top_key,
+            insert_total = True,
+            class_object = dcf_class,
+            print_info = False,
+            **sum_table_arguments)
+
+        resolved_table[sum_table_arguments['middle_key_total_insertion']] = {sum_table_arguments['bottom_key_insertion']: table_sum}     
 
     return resolved_table
 
@@ -440,6 +469,32 @@ def table_group_resolver_function(table_group_top_key, table_group_dict, dcf_cla
         # Call table resolver function for each table in the table group
         resolved_table = table_resolver_function(table_key, table_group_dict, dcf_class)
         resolved_table_group[table_key] = resolved_table
+
+    # If sum_tables mode is 'all', sum across all tables in the group 
+    # and insert into dcf_class.inp according to specifications in table_group_dict
+    if table_group_dict.get(SUM_TABLES_KEY, {}).get('mode', None) == 'all':
+        
+        sum_table_arguments = dict(table_group_dict[SUM_TABLES_KEY]['arguments'])
+        sum_table_arguments.pop('bottom_key', None)
+
+        sum, contributions = sum_all_tables_quantity(
+                    dictionary = resolved_table_group,
+                    table_group = table_group_top_key,
+                    insert_total_table_group = True,
+                    class_object = dcf_class,
+                    print_info = False,
+                    return_contributions = True,
+                    **sum_table_arguments)
+        
+        # Updating resolved_table_group with total sum and contributions across all tables in the group 
+        resolved_table_group.setdefault(table_group_top_key, {}).update({
+            sum_table_arguments['middle_key_total_group_insertion']: {
+                sum_table_arguments['bottom_key_insertion']: sum
+            },
+            sum_table_arguments['middle_key_contributions_insertion']: {
+                sum_table_arguments['bottom_key_insertion']: contributions
+            }
+        })
 
     return resolved_table_group
 

--- a/src/pyH2A/Utilities/Unit_Handler/config.py
+++ b/src/pyH2A/Utilities/Unit_Handler/config.py
@@ -94,7 +94,7 @@ DIMENSIONS = {
         "base": "USD",
         "conversions": {
             "USD": 1.0,
-            "EUR": 1.0  # Exchange rate should be adjusted via an API or manually when needed
+            "EUR": 0.8  # Exchange rate should be adjusted via an API or manually when needed
         }
     },
     "mass": {

--- a/src/pyH2A/Utilities/input_modification.py
+++ b/src/pyH2A/Utilities/input_modification.py
@@ -839,6 +839,136 @@ def sum_all_tables(dictionary, table_group, bottom_key, insert_total = False,
 	else:
 		return total
 	
+def sum_table_quantity(dictionary, 
+					   top_key, 
+					   bottom_key,
+					   insert_total = False,
+					   middle_key_total_insertion = 'Summed Total',
+					   bottom_key_insertion = 'Value',
+					   class_object = None,
+					   print_info = True):
+	'''For the provided `dictionary`, all entries in dictionary[top_key] are summed.
+
+	Parameters
+	----------
+	dictionary : dict
+		Dictionary within which function operates.
+	top_key : str
+		Top key.
+	bottom_key : str, ndarray or list
+		Bottom key.
+	insert_total : bool, optional
+		If `insert_total` is True, the total of each table is inserted in the
+		respective table.
+	middle_key_total_insertion : str, optional
+		Middle key used for insertion of total.
+	bottom_key_insertion : str, optional
+		Bottom key used for insertion of total.
+	class_object : Discounted_Cash_Flow object
+		Discounted_Cash_Flow object whose .inp attribute is modified.
+	print_info : bool, optional
+		Flag to control if information on action of ``insert()`` is printed.
+
+	Returns
+	-------
+	value : Quantity
+		Summed value across all entries in dictionary[top_key] at position bottom_key.
+	'''
+
+	value = 0.
+
+	for key in dictionary[top_key]:
+		quantity = dictionary[top_key][key][bottom_key]
+		value += quantity.base_value
+
+	value = Quantity(value, quantity.base_unit)
+
+	if insert_total is True:
+		insert(class_object, top_key, middle_key_total_insertion, bottom_key_insertion, 
+					    value, __name__, print_info = print_info)
+
+	return value
+
+def sum_all_tables_quantity(dictionary, 
+							table_group, 
+							insert_total_table_group = False,
+				   			class_object = None, 
+							middle_key_total_insertion = 'Summed Total', 
+							middle_key_total_group_insertion = 'Summed Group Total',
+							middle_key_contributions_insertion = 'Contributions',
+				   			bottom_key_insertion = 'Value', 
+							print_info = True, 
+							return_contributions = False):
+	'''
+	Sums all sums of tables within table group (assumes that sum_all_tables_quantity has already been applied to all tables in table group, 
+	so that the dictionary[top_key][middle_key_total_insertion][bottom_key_insertion] position of each table contains a Quantity object 
+	representing the sum of that table).
+	
+	Parameters
+	----------
+	dictionary : dict
+		Dictionary within which function operates.
+	table_group : str
+		String to identify table group. If a dictionary key contains the `table_group`
+		substring it is part of the table group.
+	insert_total_table_group : bool, optional
+		If `insert_total_table_group` is True, the total of across all tables
+		is inserted in class_object.inp at table_group > middle_key_total_group_insertion > bottom_key_insertion.
+	class_object : Discounted_Cash_Flow object
+		Discounted_Cash_Flow object whose .inp attribute is modified.
+	middle_key_total_insertion : str, optional
+		Middle key, in which the total of each table was previously inserted by ``sum_table_quantity()``.
+	middle_key_total_group_insertion : str, optional
+		Middle key used for insertion of total across all tables in table group.
+	middle_key_contributions_insertion : str, optional
+		Middle key used for insertion of contributions breakdown.
+	bottom_key_insertion : str, optional
+		Bottom key, in which the total of each table was previously inserted by ``sum_table_quantity()``. 
+		Also used for insertion of total across all tables in table group and contributions breakdown.
+	print_info : bool, optional
+		Flag to control if information on action of ``insert()`` is printed.
+	return_contributions : bool, optional
+		Flag to control if a dictionary with contributions breakdown (for use 
+		in cost ``Cost_Contributions_Analysis`` module) is returned and inserted in class_object.inp at 
+		table_group > middle_key_contributions_insertion > bottom_key_insertion.
+
+	Notes
+	-----
+	The contributions of each table in table_group are stored in `contributions` dictionary, 
+	which is returned if `return_contributions` is set to True. Dictionary is structured so 
+	that it can be provided to "Cost_Contributions_Analysis" class to generate a cost breakdown plot.
+	'''
+
+	total = 0.
+
+	contributions = {}
+	contributions['Data'] = {}
+	contributions['Table Group'] = table_group
+	
+	for key in dictionary:
+
+		if table_group in key:
+			value = dictionary[key][middle_key_total_insertion][bottom_key_insertion]
+			total += value.base_value
+			contributions['Data'][key] = value.base_value
+				
+	total = Quantity(total, value.base_unit)
+	contributions['Total'] = total
+
+	# Inserting total sum across all tables in table group
+	if insert_total_table_group is True:
+		insert(class_object, table_group, middle_key_total_group_insertion, bottom_key_insertion, 
+							total, __name__, print_info = print_info)
+
+	# Inserting contributions breakdown and returning contributions breakdown dictionary if return_contributions is True
+	if return_contributions is True:
+		insert(class_object, table_group, middle_key_contributions_insertion, bottom_key_insertion, 
+							contributions, __name__, print_info = print_info)
+		return total, contributions
+	
+	else:
+		return total
+
 def hourly_to_daily_power(array):
 	'''Convert array of hourly power values to array of daily power values.'''
 		

--- a/src/tests/e2e_lcoh/plugin_IO_test.py
+++ b/src/tests/e2e_lcoh/plugin_IO_test.py
@@ -10,8 +10,119 @@ def test_plugin_IO():
 
     result = pyH2A('src/tests/end_to_end/PV_E_Plugin_IO.md', 
                    'src/tests/end_to_end/')
+        
+    expected_input_x_sum_testing_dcf = {
+        'Adsorber': {
+              'Processed': 'Yes',
+              'Sum Path': 'None',
+              'Unit': 'EUR',
+              'Value': 500
+              },
+        'Compressor': {
+                'Processed': 'Yes',
+                'Sum Path': 'None',
+                'Unit': 'USD',
+                'Value': 100
+                },
+        'Summed Total': {
+            'Processed': 'Yes', 
+            'Value': Quantity(500.0, 'USD')
+            }
+        }
     
-    expected_plugin_a_input = {
+    expected_input_y_sum_testing_dcf = {
+        'Pumps': {
+           'Former Value': 0.3,
+           'Processed': 'Yes',
+           'Sum Path': 'Input X - Sum Testing > Compressor > Value',
+           'Unit': 'USD',
+           'Value': 30.0
+           },
+        'Reactor': {
+            'Former Value': 0.2,
+            'Processed': 'Yes',
+            'Sum Path': 'Input X - Sum Testing > Summed Total > Value',
+            'Unit': 'USD',
+            'Value': 100.0},
+        'Summed Total': {
+            'Processed': 'Yes', 
+            'Value': Quantity(130.0, 'USD')
+            }
+        }
+    
+    expected_input_sum_testing_dcf = {
+        'Contributions': {
+            'Processed': 'Yes',
+            'Value': {
+                'Data': {
+                    'Input X - Sum Testing': 500.0,
+                    'Input Y - Sum Testing': 130.0,
+                    'Sum Testing': 100.0
+                    },
+                'Table Group': 'Sum Testing',
+                'Total': Quantity(730.0, 'USD')
+                }
+            },
+        'Other': {
+            'Processed': 'Yes', 
+            'Sum Path': 'None', 
+            'Unit': 'USD', 
+            'Value': 100},
+        'Summed Group Total': {
+            'Processed': 'Yes', 
+            'Value': Quantity(730.0, 'USD')
+            },
+        'Summed Total': {
+            'Processed': 'Yes', 
+            'Value': Quantity(100.0, 'USD')
+            }
+        }
+
+    expected_input_z_indirect_testing_dcf = {
+        'Design': {
+            'Former Value': 0.1,
+            'Path': 'Sum Testing > Summed Group Total > Value',
+            'Processed': 'Yes',
+            'Unit': 'USD',
+            'Value': 73.0
+            },
+        'Summed Total': {
+            'Processed': 'Yes', 
+            'Value': Quantity(73.0, 'USD')
+            }
+        }
+    
+    expected_input_indirect_testing_dcf = {
+        'Contributions': {
+            'Processed': 'Yes',
+            'Value': {
+                'Data': {
+                    'Input Z - Indirect Testing': 73.0
+                    },
+                'Table Group': 'Indirect Testing',
+                'Total': Quantity(73.0, 'USD')}},
+        'Summed Group Total': {
+            'Processed': 'Yes', 
+            'Value': Quantity(73.0, 'USD')}}
+    
+    expected_individual_table_sum_dcf = {
+        'Entry A': {
+            'Path': 'None', 
+            'Processed': 'Yes', 
+            'Unit': 'USD', 
+            'Value': 1},
+        'Entry B': {
+            'Path': 'None', 
+            'Processed': 'Yes', 
+            'Unit': 'USD',
+            'Value': 2},
+        'Summed Total': {
+            'Processed': 'Yes', 
+            'Value': Quantity(3.0, 'USD')
+            }
+        }
+        
+    expected_plugin_a_input_dcf = {
         'Power': {
             'Former Value': 10,
             'Path': 'Photovoltaic > Nominal Power (kW) > Value',
@@ -21,6 +132,91 @@ def test_plugin_IO():
         }
     }
 
+    expected_plugin_a_processed_input = {
+        'Indirect Testing': {
+            'Contributions': {
+                'Value': {
+                    'Data': {
+                        'Input Z - Indirect Testing': 73.0
+                        },
+                    'Table Group': 'Indirect Testing',
+                    'Total': Quantity(73.0, 'USD')
+                    }
+                },
+            'Summed Group Total': {
+                'Value': Quantity(73.0, 'USD')
+                }
+            },
+        'Individual Table Sum': {
+            'Entry A': {
+                'Value': Quantity(1.0, 'USD')
+                },
+            'Entry B': {
+                'Value': Quantity(2.0, 'USD')
+                },
+            'Summed Total': {
+                'Value': Quantity(3.0, 'USD')
+                }
+            },
+        'Input X - Sum Testing': {
+            'Adsorber': {
+                'Value': Quantity(400.0, 'USD')
+                },
+            'Compressor': {
+                'Value': Quantity(100.0, 'USD')
+                },
+            'Summed Total': {
+                'Value': Quantity(500.0, 'USD')
+                }
+            },
+        'Input Y - Sum Testing': {
+            'Pumps': {
+                'Value': Quantity(30.0, 'USD')
+                },
+            'Reactor': {
+                'Value': Quantity(100.0, 'USD')
+                },
+            'Summed Total': {
+                'Value': Quantity(130.0, 'USD')
+                }
+            },
+        'Input Z - Indirect Testing': {
+            'Design': {
+                'Value': Quantity(73.0, 'USD')
+                },
+            'Summed Total': {
+                'Value': Quantity(73.0, 'USD')
+                }
+            },
+        'Plugin A Input': {
+            'Power': {
+                'Value': Quantity(82500000.0, 'W')
+                }
+            },
+        'Sum Testing': {
+            'Contributions': {
+                'Value': {
+                    'Data': {
+                        'Input X - Sum Testing': 500.0,
+                        'Input Y - Sum Testing': 130.0,
+                        'Sum Testing': 100.0
+                        },
+                    'Table Group': 'Sum Testing',
+                    'Total': Quantity(730.0, 'USD')
+                    }
+                },
+            'Summed Group Total': {
+                'Value': Quantity(730.0, 'USD')
+                },
+            'Other': {
+                'Value': Quantity(100.0, 'USD')
+                },
+            'Summed Total': {
+                'Value': Quantity(100.0, 'USD')
+                },
+            }
+        }
+
     expected_plugin_a_output = {
         'Energy': {
             'Processed': 'Yes',
@@ -28,7 +224,7 @@ def test_plugin_IO():
         }
     }
 
-    expected_plugin_b_input = {
+    expected_plugin_b_input_dcf = {
         'Mass': {
             'Comment': 'Value "2" is in unit kg/J, multiplying by "Plugin A Output > Energy > Value" (which is dimension energy, used in basic unit "J") gives kg',
             'Former Value': 2,
@@ -45,10 +241,19 @@ def test_plugin_IO():
             'Value': Quantity(np.array([0.5, 0.5, 0.5]), 'J / kg')
         }
     }
+    
+    check_dicts(result.base_case.inp['Input X - Sum Testing'], expected_input_x_sum_testing_dcf)
+    check_dicts(result.base_case.inp['Input Y - Sum Testing'], expected_input_y_sum_testing_dcf)
+    check_dicts(result.base_case.inp['Sum Testing'], expected_input_sum_testing_dcf)
+    check_dicts(result.base_case.inp['Input Z - Indirect Testing'], expected_input_z_indirect_testing_dcf)
+    check_dicts(result.base_case.inp['Indirect Testing'], expected_input_indirect_testing_dcf)
+    check_dicts(result.base_case.inp['Individual Table Sum'], expected_individual_table_sum_dcf)
 
-    check_dicts(result.base_case.inp['Plugin A Input'], expected_plugin_a_input)
+    check_dicts(result.base_case.plugs['Test_Plugin_A'].inp, expected_plugin_a_processed_input)
+
+    check_dicts(result.base_case.inp['Plugin A Input'], expected_plugin_a_input_dcf)
     check_dicts(result.base_case.inp['Plugin A Output'], expected_plugin_a_output)
-    check_dicts(result.base_case.inp['Plugin B Input'], expected_plugin_b_input)
+    check_dicts(result.base_case.inp['Plugin B Input'], expected_plugin_b_input_dcf)
     check_dicts(result.base_case.inp['Plugin B Output'], expected_plugin_b_output)
     
 if __name__ == '__main__':

--- a/src/tests/end_to_end/PV_E_Plugin_IO.md
+++ b/src/tests/end_to_end/PV_E_Plugin_IO.md
@@ -19,6 +19,39 @@ Name | Value | Path | Unit
 --- | --- | --- | ---
 Power | 10 | Photovoltaic > Nominal Power (kW) > Value | kW
 
+# Input X - Sum Testing
+
+Name | Value | Sum Path | Unit
+--- | --- | --- | ---
+Compressor | 100 | None | USD
+Adsorber | 500 | None | EUR
+
+# Input Y - Sum Testing
+
+Name | Value | Sum Path | Unit
+--- | --- | --- | ---
+Reactor | 20% | Input X - Sum Testing > Summed Total > Value | USD
+Pumps | 30% | Input X - Sum Testing > Compressor > Value | USD
+
+# Sum Testing
+
+Name | Value | Sum Path | Unit
+--- | --- | --- | ---
+Other | 100 | None | USD
+
+# Input Z - Indirect Testing
+
+Name | Value | Path | Unit
+--- | --- | --- | ---
+Design | 10% | Sum Testing > Summed Group Total > Value | USD
+
+# Individual Table Sum
+
+Name | Value | Path | Unit
+--- | --- | --- | ---
+Entry A | 1 | None | USD
+Entry B | 2 | None | USD
+
 # Plugin B Input
 
 Name | Value | Path | Unit | Comment


### PR DESCRIPTION
# Description

Addition of new functions to perform sum_tables and sum_all_tables with Quantity objects, integration of these functions into input_resolver to enable on-the-fly computation.

# Motivation / Background
On the fly computation of table summation enables referencing of sums in the way it worked before input_resolver was added.

# Related Issue(s)
Fixes #97 
Replaces #60 

# Type of Change
Please check all that apply:
- [X] Bug fix (non-breaking change)
- [X] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [ ] Documentation update
- [X] Test addition or update
- [X] Design / Architecture change

# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [X] Unit tests
- [X] Integration tests
- [ ] Performance tests
- [X] Manual tests / example model runs

# Checklist
- [X] Code follows pyH2A style guidelines
- [X] Self-review of code completed
- [X] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [X] No new warnings generated
- [X] Tests added / updated and passing
- [ ] Dependent changes merged and published
etc
