### PR TITLE
Fix: inexistent table when summing a group

### DIFF
--- a/src/pyH2A/Plugins/Test_Plugin_A.py
+++ b/src/pyH2A/Plugins/Test_Plugin_A.py
@@ -41,6 +41,30 @@ input_dict = {
             }
         },
     },
+    '<...> Absent Table Testing <...>': {
+        '<...>': {
+            'Value': {
+                'type': {float, int},
+                'bounds': (0, None),
+                'path': 'Sum Path'
+            },
+            'Unit': {
+                'dimension': 'mass'
+            },
+            'optional': True,
+            'description': 'Sum Test Value'
+        },
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed Total',
+                'middle_key_total_group_insertion': 'Summed Group Total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },
+    },    
     '<...> Indirect Testing <...>': {
         '<...>': {
             'Value': {

--- a/src/pyH2A/Utilities/IO/input_resolver.py
+++ b/src/pyH2A/Utilities/IO/input_resolver.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from pyH2A.Utilities.check_functions import check_type, check_if_in_options, check_dimension, check_bounds
 from pyH2A.Utilities.Unit_Handler.quantity import Quantity
+from pyH2A.Utilities.Unit_Handler import config as config
 from pyH2A.Utilities.input_modification import process_input, sum_table_quantity, sum_all_tables_quantity
 
 from tests.Utilities.Input_Resolver.input_resolver_test_data import DummyDCF, input_dict, input_dict_resolved
@@ -439,12 +440,32 @@ def table_resolver_function(top_key, table_dict, dcf_class):
         sum_table_arguments.pop('middle_key_contributions_insertion', None)
         sum_table_arguments.pop('middle_key_total_group_insertion', None)
 
+        # Determination of the base unit, from the dimension specified in input_dict
+        bottom_key = sum_table_arguments['bottom_key']
+        dimension = None
+
+        for middle_key, row_dict in table_dict.items():
+            if middle_key == SUM_TABLES_KEY:
+                continue
+
+            if bottom_key == VALUE_KEY:
+                unit_key = UNIT_KEY
+            else:
+                unit_key = bottom_key.replace(VALUE_SUFFIX, UNIT_SUFFIX)
+
+            if unit_key in row_dict:
+                dimension = row_dict[unit_key][DIMENSION_KEY]
+                break
+
+        base_unit = config.DIMENSIONS[dimension]["base"]
+
         table_sum = sum_table_quantity(
             dictionary = {top_key: resolved_table},
             top_key = top_key,
             insert_total = True,
             class_object = dcf_class,
             print_info = False,
+            base_unit = base_unit,
             **sum_table_arguments)
 
         resolved_table[sum_table_arguments['middle_key_total_insertion']] = {sum_table_arguments['bottom_key_insertion']: table_sum}     
@@ -477,6 +498,25 @@ def table_group_resolver_function(table_group_top_key, table_group_dict, dcf_cla
         sum_table_arguments = dict(table_group_dict[SUM_TABLES_KEY]['arguments'])
         sum_table_arguments.pop('bottom_key', None)
 
+        # Determination of the base unit, from the dimension specified in input_dict
+        bottom_key = table_group_dict[SUM_TABLES_KEY]['arguments']['bottom_key']
+        dimension = None
+
+        for middle_key, row_dict in table_group_dict.items():
+            if middle_key in [SUM_TABLES_KEY]:
+                continue
+
+            if bottom_key == VALUE_KEY:
+                unit_key = UNIT_KEY
+            else:
+                unit_key = bottom_key.replace(VALUE_SUFFIX, UNIT_SUFFIX)
+
+            if unit_key in row_dict:
+                dimension = row_dict[unit_key][DIMENSION_KEY]
+                break
+
+        base_unit = config.DIMENSIONS[dimension]["base"]
+        
         sum, contributions = sum_all_tables_quantity(
                     dictionary = resolved_table_group,
                     table_group = table_group_top_key,
@@ -484,6 +524,7 @@ def table_group_resolver_function(table_group_top_key, table_group_dict, dcf_cla
                     class_object = dcf_class,
                     print_info = False,
                     return_contributions = True,
+                    base_unit = base_unit,
                     **sum_table_arguments)
         
         # Updating resolved_table_group with total sum and contributions across all tables in the group 

--- a/src/pyH2A/Utilities/input_modification.py
+++ b/src/pyH2A/Utilities/input_modification.py
@@ -846,7 +846,8 @@ def sum_table_quantity(dictionary,
 					   middle_key_total_insertion = 'Summed Total',
 					   bottom_key_insertion = 'Value',
 					   class_object = None,
-					   print_info = True):
+					   print_info = True, 
+					   base_unit = None):
 	'''For the provided `dictionary`, all entries in dictionary[top_key] are summed.
 
 	Parameters
@@ -881,7 +882,7 @@ def sum_table_quantity(dictionary,
 		quantity = dictionary[top_key][key][bottom_key]
 		value += quantity.base_value
 
-	value = Quantity(value, quantity.base_unit)
+	value = Quantity(value, base_unit)
 
 	if insert_total is True:
 		insert(class_object, top_key, middle_key_total_insertion, bottom_key_insertion, 
@@ -898,7 +899,8 @@ def sum_all_tables_quantity(dictionary,
 							middle_key_contributions_insertion = 'Contributions',
 				   			bottom_key_insertion = 'Value', 
 							print_info = True, 
-							return_contributions = False):
+							return_contributions = False, 
+							base_unit = None):
 	'''
 	Sums all sums of tables within table group (assumes that sum_all_tables_quantity has already been applied to all tables in table group, 
 	so that the dictionary[top_key][middle_key_total_insertion][bottom_key_insertion] position of each table contains a Quantity object 
@@ -951,8 +953,8 @@ def sum_all_tables_quantity(dictionary,
 			value = dictionary[key][middle_key_total_insertion][bottom_key_insertion]
 			total += value.base_value
 			contributions['Data'][key] = value.base_value
-				
-	total = Quantity(total, value.base_unit)
+
+	total = Quantity(total, base_unit)				
 	contributions['Total'] = total
 
 	# Inserting total sum across all tables in table group

--- a/src/tests/e2e_lcoh/plugin_IO_test.py
+++ b/src/tests/e2e_lcoh/plugin_IO_test.py
@@ -214,7 +214,19 @@ def test_plugin_IO():
             'Summed Total': {
                 'Value': Quantity(100.0, 'USD')
                 },
-            }
+            }, 
+        'Absent Table Testing': {
+            'Contributions': {
+                'Value': {
+                    'Data': {},
+                    'Table Group': 'Absent Table Testing',
+                    'Total': Quantity(0.0, 'kg')
+                    }
+                },
+            'Summed Group Total': {
+                'Value': Quantity(0.0, 'kg')
+                }
+            },            
         }
 
     expected_plugin_a_output = {


### PR DESCRIPTION
Issue #102 

# Description

- the input_resolver obtains the base_unit from the dimension specified in input_dict
- this is passed to sum_table_quantity and sum_all_tables_quantity
- the latter use the unit that comes as a parameter, instead of determining it themselves
- add a group table to sum in Test_Plugin_A (with dimension 'mass', to vary a bit) and update plugin_IO_test accordingly to check that we obtain the expected behaviour when the table isn't found
 
 
# Motivation / Background
This is needed because if the table doesn't even exist, the sum(_all)_table_Quantity method won't find a unit in the table and can therefore not return a quantity of magnitude 0, and with the correct unit.


# Related Issue(s)
Fixes #102 
Related: #98 

# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [X] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change


# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [X] Unit tests
- [ ] Integration tests
- [ ] Performance tests
- [X] Manual tests / example model runs

## Test Details:
- plugin_IO_test  updated tot est this
- manual testing in sandbox to check if it also works on real end-to-end calcualtion (PEC_Base refctored for IO resolver) 

# Checklist
- [X] Code follows pyH2A style guidelines
- [X] Self-review of code completed
- [X] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [X] No new warnings generated
- [X] Tests added / updated and passing
- [ ] Dependent changes merged and published

