### PR TITLE
Electrolyzer_Plugin and Stored_Power_Electrolysis_Plugin - refactor corrections

### DIFF
--- a/src/pyH2A/Plugins/Electrolyzer_Plugin.py
+++ b/src/pyH2A/Plugins/Electrolyzer_Plugin.py
@@ -140,20 +140,6 @@ output_dict = {
             "description": "Operating capacity factor is set to 1."
         },
     },
-    "Planned Replacement": {
-        "Electrolyzer stack replacement": {
-            "Frequency_Value": {
-                "inserted_value": "replacement_frequency",
-                "type": {float,},
-                "dimension": "time",
-            },
-            "add_processed": False,
-            "insert_path": False,
-            "optional": False,
-            "description": "Frequency of electrolyzer stack replacements in years, \
-                            calculated from replacement time and hourly irradiation data."
-        },
-    },
     "Electrolyzer": {
         "Scaling factor": {
             "Value": {
@@ -165,6 +151,15 @@ output_dict = {
             "description": "CAPEX scaling factor for electrolyzer calculated based \
                             on CAPEX multiplier, reference and nominal power."
         },
+        "Stack lifetime": {
+            "Value": {
+                "inserted_value": "stack_lifetime",
+                "type": {float,},
+                "dimension": "time",
+            },
+            "optional": False,
+            "description": "Lifetime of electrolyzer stack replacements in years, calculated from replacement time and hourly irradiation data."
+        },                
         "Yearly operation data": {
             "Year_Value": {
                 "inserted_value": "yearly_data_year",
@@ -183,15 +178,6 @@ output_dict = {
             },                      
             "optional": False,
             "description": "Yearly operation data of electrolyzer: year, H2 produced, duration of operation."
-        },
-        "H2 production (yearly)": {
-            "Value": {
-                "inserted_value": "h2_production",
-                "type": {np.ndarray,},
-                "dimension": "mass / time",
-            },
-            "optional": False,
-            "description": "Yearly hydrogen production."
         },
     },
     "Power Generation": {
@@ -251,12 +237,11 @@ class Electrolyzer_Plugin:
         electrolysis power capacity and hourly power generation data.
     Technical Operating Parameters and Specifications >	Operating capacity factor > Value : float
         Operating capacity factor is set to 1.
-    Planned Replacement > Electrolyzer stack replacement > Frequency : float
-        Frequency of electrolyzer stack replacements, calculated from replacement time and hourly
-        irradiation data.
     Electrolyzer > Scaling factor > Value : float
         CAPEX scaling factor for electrolyzer calculated based on CAPEX multiplier, 
         reference and nominal power.
+    Electrolyzer > Stack lifetime > Value : float
+        Frequency of electrolyzer stack replacements, calculated from replacement time and hourly irradiation data.        
     Electrolyzer > Yearly operation data > Year_Value : nd.array
         Yearly operation data of electrolyzer : year.
     Electrolyzer > Yearly operation data > Production_Value : nd.array
@@ -277,7 +262,7 @@ class Electrolyzer_Plugin:
         self.input_dict_resolved = input_resolver_function(input_dict, dcf, 'Electrolyzer_Plugin')
 
         self.calculate_H2_production(dcf)
-        self.replacement_frequency = calculate_stack_replacement(self.yearly_data_duration, 
+        self.stack_lifetime = calculate_stack_replacement(self.yearly_data_duration, 
                                     self.input_dict_resolved['Electrolyzer']['Replacement time']['Value'].unit['h'])
         self.calculate_scaling_factors()
 
@@ -388,7 +373,7 @@ def calculate_stack_replacement(operation_hours, replacement_time):
     stack_usage = cumulative_running_time / replacement_time
 
     number_of_replacements = np.floor_divide(stack_usage[-1], 1)
-    replacement_frequency = len(stack_usage) / (number_of_replacements + 1.)
+    stack_lifetime = len(stack_usage) / (number_of_replacements + 1.)
 
-    return Quantity(replacement_frequency, 'year') # the inputs being : (hours of operation in the year, hours of operation before replacement), 
+    return Quantity(stack_lifetime, 'year') # the inputs being : (hours of operation in the year, hours of operation before replacement), 
                                                    # the result corresponds to the number of years between replacements

--- a/src/pyH2A/Plugins/Stored_Power_Electrolysis_Plugin.py
+++ b/src/pyH2A/Plugins/Stored_Power_Electrolysis_Plugin.py
@@ -98,8 +98,10 @@ input_dict = {
             },                     
             "optional": False,
             "description": "Yearly operation data of electrolyzer: year, H2 produced and duration of operation"
-        },          
-        "H2 production (yearly)": {
+        }, 
+    },                 
+    "Technical Operating Parameters and Specifications":{       
+        "Plant design capacity": {
             "Value": {
                 "type": {np.ndarray},
                 "bounds": (0, None)
@@ -108,7 +110,7 @@ input_dict = {
                 "dimension": "mass / time"
             },
             "optional": False,
-            "description": "Yearly hydrogen production."
+            "description": "Yearly-averaged hydrogen production flowrate."
         },
     },
     "Power Generation": {
@@ -138,15 +140,13 @@ output_dict = {
             "description": "Plant design capacity in mass flowrate of H2 calculated from installed electrolysis power capacity and hourly power generation data."
         },
     },
-    "Planned Replacement": {
-        "Electrolyzer stack replacement": {
-            "Frequency_Value": {
-                "inserted_value": "replacement_frequency",
+    "Electrolyzer": {
+        "Stack lifetime": {
+            "Value": {
+                "inserted_value": "stack_lifetime",
                 "type": {float,},
                 "dimension": "time",
             },
-            "add_processed": False,
-            "insert_path": False,
             "optional": False,
             "description": "Frequency of electrolyzer stack replacements, calculated from replacement time and hourly irradiation data."
         },
@@ -192,7 +192,7 @@ class Stored_Power_Electrolysis_Plugin:
         Yearly operation data of electrolyzer : H2 produced during the year.
     Electrolyzer > Yearly operation data > Duration_Value : nd.array
         Yearly operation data of electrolyzer : duration of operation during the year.                
-    Electrolyzer > H2 production (yearly) > Value : nd.array
+    Technical Operating Parameters and Specifications > Plant design capacity > Value : nd.array
         Yearly hydrogen production.
     Power Generation > Stored energy (daily) > Value : dict
         Energy stored in battery daily (dictionary of years).
@@ -202,7 +202,7 @@ class Stored_Power_Electrolysis_Plugin:
     Technical Operating Parameters and Specifications > Plant design capacity > Value : nd.array
         Plant design capacity in (mass of H2)/time calculated from installed 
         electrolysis power capacity and hourly power generation data.
-    Planned Replacement > Electrolyzer stack replacement > Frequency : float
+    Electrolyzer > Stack lifetime > Value : float
         Frequency of electrolyzer stack replacements in years, calculated from replacement time and hourly
         irradiation data.
     Power Consumption > Stored energy electrolysis (yearly) > Value : nd.array
@@ -217,7 +217,7 @@ class Stored_Power_Electrolysis_Plugin:
         self.calculate_H2_production(dcf)
         self.on_demand = "on_demand"
 
-        self.replacement_frequency = calculate_stack_replacement(self.operation_hours, # operation hours being for each year, the result is in years between replacement
+        self.stack_lifetime = calculate_stack_replacement(self.operation_hours, # operation hours being for each year, the result is in years between replacement
                                                                  self.input_dict_resolved['Electrolyzer']['Replacement time']['Value'].unit['h']) 
                                                                 
         output_inserter_function(output_dict, self, dcf, 'Stored_Power_Electrolysis_Plugin') 
@@ -257,8 +257,8 @@ class Stored_Power_Electrolysis_Plugin:
                                                    self.input_dict_resolved['Electrolyzer']['Hydrogen yield per unit energy']['Value'].unit['kg/J'],
                                                    power_increase_ratio)
         
-        old_h2_production = self.input_dict_resolved['Electrolyzer']['H2 production (yearly)']['Value'].unit['kg/year']
-
+        old_h2_production = self.input_dict_resolved['Technical Operating Parameters and Specifications']['Plant design capacity']['Value'].unit['kg/year']
+        
         self.new_h2_production = old_h2_production.copy()
         self.new_h2_production[-len(additional_h2_production):] += additional_h2_production
         self.new_h2_production = Quantity(self.new_h2_production, 'kg/year')

--- a/src/tests/plugins/electrolyzer_plugin_test.py
+++ b/src/tests/plugins/electrolyzer_plugin_test.py
@@ -120,7 +120,7 @@ class DummyDCF:
             "expected": {
                 "h2_production": Quantity(np.array([0.0, 0.0, 2035.0, 2035.0]), 'kg/year'),
                 "scaling_factor": Quantity(0.9249598065992481, '-'),
-                "replacement_frequency": Quantity(2.0, 'year'),
+                "stack_lifetime": Quantity(2.0, 'year'),
                 "yearly_data_year": Quantity(np.array([2026.0, 2027.0]),'-'),
                 "yearly_data_production": Quantity(np.array([2035.0, 2035.0]),'kg'),
                 "yearly_data_duration": Quantity(np.array([20.0, 20.0]),'h'),                                
@@ -221,8 +221,8 @@ def test_electrolyzer_plugin(case):
         abs=tolerance
     )
     
-    assert plugin.replacement_frequency.unit['year'] == pytest.approx(
-        expected["replacement_frequency"].unit['year'],
+    assert plugin.stack_lifetime.unit['year'] == pytest.approx(
+        expected["stack_lifetime"].unit['year'],
         abs=tolerance
     )
 

--- a/src/tests/plugins/stored_power_electrolysis_plugin_test.py
+++ b/src/tests/plugins/stored_power_electrolysis_plugin_test.py
@@ -48,11 +48,6 @@ class DummyDCF:
                 "Replacement time": {
                     "Value": electrolyzer_replacement_time_h, 
                     "Unit" : "h"},
-                "H2 production (yearly)": {
-                    "Value": electrolyzer_yearly_H2_production_kg, 
-                    "Unit" : "kg / year",
-                    "Processed": "Yes"
-                    },
                 "Yearly operation data": {
                     "Year_Value" : yearly_operation_data_year, 
                     "Year_Unit" : "-", 
@@ -63,6 +58,13 @@ class DummyDCF:
                     "Processed": "Yes"
                     },
             },
+            "Technical Operating Parameters and Specifications": {
+                "Plant design capacity": {
+                    "Value": electrolyzer_yearly_H2_production_kg, 
+                    "Unit" : "kg / year",
+                    "Processed": "Yes"
+                    },       
+            },                         
             "Power Generation": {
                 "Stored energy (daily)": {
                     "Value": stored_power_daily_kWh, 
@@ -97,7 +99,7 @@ class DummyDCF:
             },
             "expected": {
                 "energy_consumption": Quantity(np.array([1760.0, 1280.0]), "kWh"),
-                "replacement_frequency": Quantity(2.0, "year"),
+                "stack_lifetime": Quantity(2.0, "year"),
                 "new_h2_production": Quantity(np.array([1.0, 8.0]), "kg/year"),
             },
         }
@@ -123,8 +125,8 @@ def test_stored_power_electrolysis_plugin(case):
         atol=tolerance,
     )
     
-    assert plugin.replacement_frequency.unit['s'] == pytest.approx(
-        expected["replacement_frequency"].unit['s'],
+    assert plugin.stack_lifetime.unit['s'] == pytest.approx(
+        expected["stack_lifetime"].unit['s'],
         abs=tolerance,
     )
     


### PR DESCRIPTION
# Description

- introduce ``Electrolyzer > Stack lifetime`` instead of inserting directly ``Planned Replacement > Electrolyzer stack replacement`` (which was conflicting with the possibility to specify a frequency and a cost separately). IOW we calculate a lifetime, and the replacement frequency points to this lifetime in the input file, instead of hardcoding in the plugin the insertion of a replacement frequency.
- remove useless H2 production (yearly) mid key, which is now Plant design capacity 
- update plugin tests accordingly

# Motivation / Background
- The end-to-end tests enlightened that we couldn't simply insert a frequency_value on the one hand, and specify a cost_value in input file on the other hand, without creating issues (see the fixed issues below)
- it also appeared that ``H2 production (yearly)`` was a relics from the pre-IO resolver version of the code, because it was just a synonym of the Plant design capacity, expressed in a different system of units (which is no longer relevant)

# Related Issue(s)
Fixes #109 and #115 


# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [X] Breaking change (affects existing behavior)
- [ ] Documentation update
- [X] Test addition or update
- [X] Design / Architecture change


# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [X] Unit tests
- [ ] Integration tests
- [ ] Performance tests
- [ ] Manual tests / example model runs

## Test Details:
Respective plugin tests and end-to-end PV_E test run fine locally, when all the plugin refactor modifs are put together

# Checklist
- [X] Code follows pyH2A style guidelines
- [X] Self-review of code completed
- [ ] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [X] No new warnings generated
- [X] Tests added / updated and passing
- [ ] Dependent changes merged and published
