### PR TITLE
feat: scikit umfpack pardiso optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ Documentation for pyH2A is available at: https://pyh2a.readthedocs.io
 
 pyH2A uses Python >=3.7 with the following libraries: `NumPy`, `SciPy`, `Pandas`, `Matplotlib` and `Click`
 
+For sparse linear solves in LCA workflows, pyH2A can optionally use faster sparse solvers:
+- `pypardiso` (MKL-backed, fast on Windows/Linux)
+- `scikit-umfpack` (UMFPACK-backed, cross-platform including Mac)
+
+If either is installed, pyH2A will use it automatically for performance. If neither is available, pyH2A falls back to SciPy's default sparse solvers.
+
+To install performance backends:
+```bash
+# For Windows/Linux with MKL support:
+pip install pypardiso
+
+# For cross-platform support (recommended for Mac):
+pip install scikit-umfpack
+
+# Or install the platform-appropriate backend automatically:
+pip install pyH2A[performance]
+```
+
+With `pyH2A[performance]`, pip uses platform markers to install:
+- `pypardiso` on Windows/Linux
+- `scikit-umfpack` on macOS
+
 # Use
 
 pyH2A can be used from the command line:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,12 @@ dependencies = [
     "pytest>=8.4.2",
     "scipy>=1.13.1",
 ]
+
+[project.optional-dependencies]
+performance = [
+    "pypardiso>=0.4.7; sys_platform == 'win32' or sys_platform == 'linux'",
+    "scikit-umfpack>=0.3.3; sys_platform == 'darwin'",
+]
+
+[project.scripts]
+pyH2A = "pyH2A.cli_pyH2A:cli"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,11 @@ include_package_data = True
 [options.packages.find]
 where = src
 
+[options.extras_require]
+performance =
+    pypardiso>=0.4.7; sys_platform == "win32" or sys_platform == "linux"
+    scikit-umfpack>=0.3.3; sys_platform == "darwin"
+
 [options.entry_points]
 console_scripts =
     pyH2A = pyH2A.cli_pyH2A:cli


### PR DESCRIPTION
# scikit-umfpack and pypardiso as optional dependency

# Description
scikit-umfpack and pypardiso can support backend performance for lca-related matrix calculations.

# Motivation / Background
- To speed up LCA calculation and in turn reduce the heavy MC analysis computation for lca-related metrics

# Type of Change
Please check all that apply:
- [ ] Bug fix (non-breaking change)
- [X] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [X] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change
etc

# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [ ] Unit tests
- [ ] Integration tests
- [ ] Performance tests
- [X] Manual tests / example model runs

## Test Details:
After the installation, PVE.md with new lca matrices was successfully used as an input file for lca-based Monte Carlo analysis.
scikit-umfpack was installed using ´´´conda install -c conda-forge scikit-umfpack´´´.  In lca_lib.py Pardiso was set as none inorder to enforce umfpack as solver and Monte Carlo analysis was performed successfully.

# Checklist
- [X] Code follows pyH2A style guidelines
- [X] Self-review of code completed
- [ ] Comments added in complex or critical sections
- [X] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [X] No new warnings generated
- [ ] Tests added / updated and passing
- [ ] Dependent changes merged and published
etc

Note: scikit-umfpack does work on Windows, though it's noticeably more involved to set up than on Linux or macOS.
The practical path is conda-forge. The package is available on conda-forge for win-64,  so conda install -c conda-forge scikit-umfpack will pull in SuiteSparse (which contains UMFPACK) along with everything else. This is by far the easiest route — pip install scikit-umfpack on Windows has historically been problematic because SuiteSparse isn't on PyPI and the build needs a C compiler, BLAS with CBLAS symbols, NumPy, SuiteSparse, and SWIG.
