### PR TITLE
Fix: Fixing a bug where sum_all_tables_quantity crashes when no table in table group exists

### DIFF
--- a/src/pyH2A/Plugins/Test_Plugin_A.py
+++ b/src/pyH2A/Plugins/Test_Plugin_A.py
@@ -41,6 +41,31 @@ input_dict = {
             }
         },
     },
+    '<...> Absent Table Testing <...>': {
+        '<...>': {
+            'Value': {
+                'type': {float, int},
+                'bounds': (0, None),
+                'path': 'Sum Path'
+            },
+            'Unit': {
+                'dimension': 'mass'
+            },
+            'optional': True,
+            'description': 'Testing for applying sum_all_tables to non-existent table group.'
+        },
+        'sum_tables': {
+            'mode': 'all',
+            'arguments': {
+                'bottom_key': 'Value',
+                'middle_key_total_insertion': 'Summed Total',
+                'middle_key_total_group_insertion': 'Summed Group Total',
+                'middle_key_contributions_insertion': 'Contributions',
+                'bottom_key_insertion': 'Value'
+            }
+        },
+    },    
+
     '<...> Indirect Testing <...>': {
         '<...>': {
             'Value': {

--- a/src/pyH2A/Utilities/IO/input_resolver.py
+++ b/src/pyH2A/Utilities/IO/input_resolver.py
@@ -1,9 +1,15 @@
 import pprint as pp
 import numpy as np
 
-from pyH2A.Utilities.check_functions import check_type, check_if_in_options, check_dimension, check_bounds
+from pyH2A.Utilities.check_functions import (check_type, 
+                                             check_if_in_options, 
+                                             check_dimension, 
+                                             check_bounds)
 from pyH2A.Utilities.Unit_Handler.quantity import Quantity
-from pyH2A.Utilities.input_modification import process_input, sum_table_quantity, sum_all_tables_quantity
+from pyH2A.Utilities.input_modification import (process_input,
+                                                sum_table_quantity, 
+                                                sum_all_tables_quantity, 
+                                                retrieve_base_unit)
 
 from tests.Utilities.Input_Resolver.input_resolver_test_data import DummyDCF, input_dict, input_dict_resolved
 
@@ -620,12 +626,15 @@ def table_resolver_function(top_key, table_dict, dcf_class):
         sum_table_arguments.pop('middle_key_contributions_insertion', None)
         sum_table_arguments.pop('middle_key_total_group_insertion', None)
 
+        base_unit = retrieve_base_unit(table_dict)
+
         table_sum = sum_table_quantity(
             dictionary = {top_key: resolved_table},
             top_key = top_key,
             insert_total = True,
             class_object = dcf_class,
             print_info = False,
+            base_unit = base_unit,
             **sum_table_arguments)
 
         resolved_table[sum_table_arguments['middle_key_total_insertion']] = {sum_table_arguments['bottom_key_insertion']: table_sum}     
@@ -674,6 +683,8 @@ def table_group_resolver_function(table_group_top_key, table_group_dict, dcf_cla
         
         sum_table_arguments = dict(table_group_dict[SUM_TABLES_KEY]['arguments'])
         sum_table_arguments.pop('bottom_key', None)
+        
+        base_unit = retrieve_base_unit(table_group_dict)
 
         sum, contributions = sum_all_tables_quantity(
                     dictionary = resolved_table_group,
@@ -682,6 +693,7 @@ def table_group_resolver_function(table_group_top_key, table_group_dict, dcf_cla
                     class_object = dcf_class,
                     print_info = False,
                     return_contributions = True,
+                    base_unit = base_unit,
                     **sum_table_arguments)
         
         # Updating resolved_table_group with total sum and contributions across all tables in the group 

--- a/src/pyH2A/Utilities/input_modification.py
+++ b/src/pyH2A/Utilities/input_modification.py
@@ -8,6 +8,7 @@ import operator
 import numpy as np
 
 from pyH2A.Utilities.Unit_Handler import Quantity
+from pyH2A.Utilities.Unit_Handler.config import DIMENSIONS
 
 def import_plugin(plugin_name, plugin_module):
 	'''Importing module.
@@ -865,6 +866,7 @@ def sum_all_tables(dictionary, table_group, bottom_key, insert_total = False,
 def sum_table_quantity(dictionary, 
 					   top_key, 
 					   bottom_key,
+			   		   base_unit = None,
 					   insert_total = False,
 					   middle_key_total_insertion = 'Summed Total',
 					   bottom_key_insertion = 'Value',
@@ -880,6 +882,8 @@ def sum_table_quantity(dictionary,
 		Top key.
 	bottom_key : str, ndarray or list
 		Bottom key.
+	base_unit : str, optional
+		Base unit which is used for the creation of the output quantity object.	
 	insert_total : bool, optional
 		If `insert_total` is True, the total of each table is inserted in the
 		respective table.
@@ -904,7 +908,7 @@ def sum_table_quantity(dictionary,
 		quantity = dictionary[top_key][key][bottom_key]
 		value += quantity.base_value
 
-	value = Quantity(value, quantity.base_unit)
+	value = Quantity(value, base_unit)
 
 	if insert_total is True:
 		insert(class_object, top_key, middle_key_total_insertion, bottom_key_insertion, 
@@ -916,6 +920,7 @@ def sum_all_tables_quantity(dictionary,
 							table_group, 
 							insert_total_table_group = False,
 				   			class_object = None, 
+							base_unit = None,
 							middle_key_total_insertion = 'Summed Total', 
 							middle_key_total_group_insertion = 'Summed Group Total',
 							middle_key_contributions_insertion = 'Contributions',
@@ -939,6 +944,8 @@ def sum_all_tables_quantity(dictionary,
 		is inserted in class_object.inp at table_group > middle_key_total_group_insertion > bottom_key_insertion.
 	class_object : Discounted_Cash_Flow object
 		Discounted_Cash_Flow object whose .inp attribute is modified.
+	base_unit : str, optional
+		Base unit which is used for the creation of the output quantity object.
 	middle_key_total_insertion : str, optional
 		Middle key, in which the total of each table was previously inserted by ``sum_table_quantity()``.
 	middle_key_total_group_insertion : str, optional
@@ -974,8 +981,8 @@ def sum_all_tables_quantity(dictionary,
 			value = dictionary[key][middle_key_total_insertion][bottom_key_insertion]
 			total += value.base_value
 			contributions['Data'][key] = value.base_value
-				
-	total = Quantity(total, value.base_unit)
+
+	total = Quantity(total, base_unit)
 	contributions['Total'] = total
 
 	# Inserting total sum across all tables in table group
@@ -1011,3 +1018,17 @@ def daily_to_yearly_power(dictionary):
 	yearly_power = stacked_array.sum(axis = 1)
 
 	return yearly_power
+
+def retrieve_base_unit(table_dictionary):
+	'''Retrieve dimension of unit from input dictionary.
+	Return base unit of retrieved dimension using DIMENSIONS from unit handler.
+	'''
+
+	for row in table_dictionary.values():
+		if isinstance(row, dict):
+			for key, value in row.items():
+				if "Unit" in key and isinstance(value, dict):
+
+					dimension = value.get("dimension")
+					return DIMENSIONS[dimension]["base"]
+

--- a/src/tests/e2e_lcoh/plugin_IO_test.py
+++ b/src/tests/e2e_lcoh/plugin_IO_test.py
@@ -214,7 +214,19 @@ def test_plugin_IO():
             'Summed Total': {
                 'Value': Quantity(100.0, 'USD')
                 },
-            }
+            },
+        'Absent Table Testing': {
+            'Contributions': {
+                'Value': {
+                    'Data': {},
+                    'Table Group': 'Absent Table Testing',
+                    'Total': Quantity(0.0, 'kg')
+                    }
+                },
+            'Summed Group Total': {
+                'Value': Quantity(0.0, 'kg')
+                }
+            }, 
         }
 
     expected_plugin_a_output = {


### PR DESCRIPTION
# Description

Fixing absent table bug for sum_all_tables_quantity

# Motivation / Background


# Related Issue(s)

Closes #102 
Closes #106 

# Type of Change
Please check all that apply:
- [X] Bug fix (non-breaking change)
- [ ] New feature (non-breaking)
- [ ] Breaking change (affects existing behavior)
- [ ] Documentation update
- [ ] Test addition or update
- [ ] Design / Architecture change


# How Has This Been Tested?
Describe tests performed to verify the change. Include instructions to reproduce if relevant.
- [X] Unit tests
- [X] Integration tests
- [ ] Performance tests
- [X] Manual tests / example model runs


# Checklist
- [X] Code follows pyH2A style guidelines
- [X] Self-review of code completed
- [X] Comments added in complex or critical sections
- [ ] Documentation updated (docstrings, README, RedTheDocs)
- [ ] Example input YAML or scripts updated if relevant
- [ ] No new warnings generated
- [ ] Tests added / updated and passing
- [ ] Dependent changes merged and published
etc

