### PR TITLE
Bug: fix PEC/Solar plugin outputs

### DIFF
--- a/src/tests/plugins/pec_plugin_test.py
+++ b/src/tests/plugins/pec_plugin_test.py
@@ -94,7 +94,7 @@ class DummyDCF:
                 "total_solar_collection_area": Quantity(47057.399999999994, 'm2'),
                 "cell_cost": Quantity(988205399.9999998, 'USD'),
                 "cell_number": Quantity(26143.0, '-'),
-                "mol_H2_per_m2_per_day": Quantity(10.6256954979, 'mol/day/m2'),
+                "mol_H2_per_m2_per_day": Quantity(10.625699702590028, 'mol/day/m2'),
                 "flowrate_H2_per_cell": Quantity(0.0382525189293241, 'kg/day'),
                 "total_land_area": Quantity(5348817.431990256, 'm2'),
             },

--- a/src/tests/plugins/solar_thermal_plugin_test.py
+++ b/src/tests/plugins/solar_thermal_plugin_test.py
@@ -52,7 +52,7 @@ class DummyDCF:
                 "additional_land_area": 0.0,
             },
             "expected": {
-                "area": Quantity(42783.952830200986, "m2"),
+                "area": Quantity(42783.93590009135, "m2"),
             },
         }
     ],


### PR DESCRIPTION

# Description

This PR remove assert error coming due to chnage in values of the acre and eV conversion constants.

* **PEC plugin**: Updated `mol_H2_per_m2_per_day` calculation
* **Solar Thermal plugin**: Updated area-related calculations

These updates ensure consistency with the constants. Corresponding unit tests have been updated to reflect the corrected expected values.

# Motivation / Background

Small differences in conversion constants led to mismatches in high-precision outputs. For pyH2A workflows, numerical reproducibility is critical, especially for regression testing and cross-model comparisons.

# Type of Change

Please check all that apply:

* [x] Bug fix (non-breaking change)
* [ ] New feature (non-breaking)
* [ ] Breaking change (affects existing behavior)
* [ ] Documentation update
* [x] Test addition or update
* [ ] Design / Architecture change

# How Has This Been Tested?

The change has been validated through:

* [x] Unit tests
* [ ] Integration tests
* [ ] Performance tests
* [x] Manual tests / example model runs

## Test Details:

* Verified outputs match expected tolerance (1e-13)
* Updated failing unit tests in:

  * PEC plugin
  * Solar Thermal plugin
* Ran full test suite:
  pytest

# Checklist

* [x] Code follows pyH2A style guidelines
* [x] Self-review of code completed
* [x] Comments added in complex or critical sections
* [ ] Documentation updated (docstrings, README, ReadTheDocs)
* [ ] Example input YAML or scripts updated if relevant
* [x] No new warnings generated
* [x] Tests updated and passing
* [ ] Dependent changes merged and published

# Screenshots / Examples (if applicable)
<img width="1153" height="522" alt="image" src="https://github.com/user-attachments/assets/6e4fcbef-0144-4347-bc7e-be91f2a3108a" />

